### PR TITLE
feat(composite): create path for composite products

### DIFF
--- a/app/Http/Controllers/Apps/ProductController.php
+++ b/app/Http/Controllers/Apps/ProductController.php
@@ -49,9 +49,15 @@ class ProductController extends Controller
         // get categories
         $categories = Category::all();
 
+        // get non-composite products for composite component selection
+        $products = Product::where('is_composite', false)
+            ->orderBy('title')
+            ->get(['id', 'title', 'sell_price', 'is_composite']);
+
         // return inertia
         return Inertia::render('Dashboard/Products/Create', [
             'categories' => $categories,
+            'products' => $products,
         ]);
     }
 
@@ -76,6 +82,7 @@ class ProductController extends Controller
             'stock' => 'required|integer|min:0',
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
+            ...$this->compositeRules(),
         ]);
         // upload image
         $image = $request->file('image');
@@ -94,9 +101,15 @@ class ProductController extends Controller
             'stock' => $request->stock,
             'min_stock' => $request->min_stock ?? 0,
             'max_stock' => $request->max_stock ?? 0,
+            'is_composite' => $request->boolean('is_composite'),
         ]);
 
-        $this->stockMutationService->recordInitialStock($product, $request->user()?->id);
+        if ($request->boolean('is_composite')) {
+            $this->validateComponentProducts($request);
+            $this->syncComponents($product, $request->input('components'));
+        } else {
+            $this->stockMutationService->recordInitialStock($product, $request->user()?->id);
+        }
         $this->auditLogService->log(
             event: 'product.created',
             module: 'products',
@@ -120,9 +133,16 @@ class ProductController extends Controller
         // get categories
         $categories = Category::all();
 
+        // get non-composite products for composite component selection
+        $products = Product::where('is_composite', false)
+            ->where('id', '!=', $product->id)
+            ->orderBy('title')
+            ->get(['id', 'title', 'sell_price', 'is_composite']);
+
         return Inertia::render('Dashboard/Products/Edit', [
-            'product' => $product,
+            'product' => $product->load('components'),
             'categories' => $categories,
+            'products' => $products,
         ]);
     }
 
@@ -149,7 +169,16 @@ class ProductController extends Controller
             'sell_price' => 'required',
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
+            ...$this->compositeRules(),
         ]);
+
+        if ($request->boolean('is_composite')) {
+            $this->validateComponentProducts($request, $product);
+        } elseif ($product->is_composite && $product->components()->exists()) {
+            return back()->withErrors([
+                'components' => 'Produk komposit harus memiliki minimal satu komponen.',
+            ]);
+        }
 
         // check image update
         if ($request->file('image')) {
@@ -171,7 +200,12 @@ class ProductController extends Controller
                 'category_id' => $request->category_id,
                 'buy_price' => $request->buy_price,
                 'sell_price' => $request->sell_price,
+                'is_composite' => $request->boolean('is_composite'),
             ]);
+
+            if ($request->boolean('is_composite')) {
+                $this->syncComponents($product, $request->input('components'));
+            }
 
             $this->logProductUpdate($product, $before);
 
@@ -187,7 +221,12 @@ class ProductController extends Controller
             'category_id' => $request->category_id,
             'buy_price' => $request->buy_price,
             'sell_price' => $request->sell_price,
+            'is_composite' => $request->boolean('is_composite'),
         ]);
+
+        if ($request->boolean('is_composite')) {
+            $this->syncComponents($product, $request->input('components'));
+        }
 
         $this->logProductUpdate($product, $before);
 
@@ -223,6 +262,42 @@ class ProductController extends Controller
 
         // redirect
         return back();
+    }
+
+    private function compositeRules(): array
+    {
+        return [
+            'is_composite' => 'nullable|boolean',
+            'components' => 'required_if:is_composite,1,true|array|min:1',
+            'components.*.component_product_id' => 'required|integer|distinct|exists:products,id',
+            'components.*.qty' => 'required|integer|min:1',
+        ];
+    }
+
+    private function validateComponentProducts(Request $request, ?Product $product = null): void
+    {
+        $componentIds = collect($request->input('components'))
+            ->pluck('component_product_id')
+            ->unique();
+
+        if ($product && $componentIds->contains($product->id)) {
+            abort(422, 'Produk tidak bisa menjadi komponen dirinya sendiri.');
+        }
+
+        $compositeCount = Product::whereIn('id', $componentIds)->where('is_composite', true)->count();
+
+        if ($compositeCount > 0) {
+            abort(422, 'Komponen tidak boleh produk komposit lain.');
+        }
+    }
+
+    private function syncComponents(Product $product, ?array $components): void
+    {
+        $product->components()->sync(
+            collect($components)->mapWithKeys(fn (array $c) => [
+                $c['component_product_id'] => ['qty' => (int) $c['qty']],
+            ])
+        );
     }
 
     private function logProductUpdate(Product $product, array $before): void

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -236,6 +236,9 @@ class TransactionController extends Controller
             return redirect()->back()->with('error', 'Product not found.');
         }
 
+        // ponytail: composite branch skips unit logic; null unit_id is fine for composite carts
+        $unitId = null;
+
         // Composite: check component stock
         if ($product->is_composite) {
             $product->load('components');

--- a/app/Services/PricingService.php
+++ b/app/Services/PricingService.php
@@ -156,7 +156,10 @@ class PricingService
     private function buildPreview(Collection $carts, ?Customer $customer, Collection $rules): array
     {
         $items = $carts->map(function (Cart $cart) {
-            $baseUnitPrice = (int) $cart->product->sell_price;
+            // ponytail: composite sell_price is 0; unit price = stored cart price / qty
+            $baseUnitPrice = $cart->product->is_composite
+                ? (int) round($cart->price / max(1, (int) $cart->qty))
+                : (int) $cart->product->sell_price;
 
             return [
                 'cart_id' => $cart->id,

--- a/resources/js/Pages/Dashboard/Products/Create.jsx
+++ b/resources/js/Pages/Dashboard/Products/Create.jsx
@@ -13,9 +13,11 @@ import {
     IconPhoto,
     IconBarcode,
     IconCurrencyDollar,
+    IconTrash,
+    IconBoxes,
 } from "@tabler/icons-react";
 
-export default function Create({ categories }) {
+export default function Create({ categories, products }) {
     const { errors } = usePage().props;
 
     const { data, setData, post, processing } = useForm({
@@ -28,6 +30,8 @@ export default function Create({ categories }) {
         buy_price: "",
         sell_price: "",
         stock: "",
+        is_composite: false,
+        components: [],
     });
 
     const [selectedCategory, setSelectedCategory] = useState(null);
@@ -38,6 +42,53 @@ export default function Create({ categories }) {
         setData("category_id", value?.id || "");
     };
 
+    const toggleComposite = (checked) => {
+        setData("is_composite", checked);
+    };
+
+    const addComponent = () => {
+        setData("components", [
+            ...data.components,
+            { component_product_id: "", qty: 1 },
+        ]);
+    };
+
+    const updateComponent = (index, field, value) => {
+        const components = data.components.map((c, i) =>
+            i === index ? { ...c, [field]: value } : c
+        );
+        setData("components", components);
+    };
+
+    const removeComponent = (index) => {
+        setData(
+            "components",
+            data.components.filter((_, i) => i !== index)
+        );
+    };
+
+    const availableProducts = (selectedIndex) =>
+        products.filter(
+            (p) =>
+                !p.is_composite &&
+                !data.components.some(
+                    (c, i) =>
+                        i !== selectedIndex &&
+                        c.component_product_id === p.id
+                )
+        );
+
+    const estimatedSellPrice = data.is_composite
+        ? data.components.reduce((total, c) => {
+              const product = products.find(
+                  (p) => p.id === Number(c.component_product_id)
+              );
+              return product
+                  ? total + product.sell_price * (Number(c.qty) || 0)
+                  : total;
+          }, 0)
+        : data.sell_price;
+
     const handleImageChange = (e) => {
         const file = e.target.files[0];
         if (file) {
@@ -46,8 +97,13 @@ export default function Create({ categories }) {
         }
     };
 
-    const submit = (e) => {
+    // ponytail: zero-out stock/sell_price for composite; collapse if Inertia ever accepts pre-send transforms
+    const submitCompositeAware = (e) => {
         e.preventDefault();
+        if (data.is_composite) {
+            setData("sell_price", 0);
+            setData("stock", 0);
+        }
         post(route("products.store"), {
             onSuccess: () => toast.success("Produk berhasil ditambahkan"),
             onError: () => toast.error("Gagal menyimpan produk"),
@@ -73,7 +129,7 @@ export default function Create({ categories }) {
                 </h1>
             </div>
 
-            <form onSubmit={submit}>
+            <form onSubmit={submitCompositeAware}>
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                     {/* Left Column - Image */}
                     <div className="lg:col-span-1">
@@ -184,6 +240,21 @@ export default function Create({ categories }) {
                                 <IconCurrencyDollar size={18} />
                                 Harga & Stok
                             </h3>
+                            <label className="flex items-center gap-2 mb-4 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={data.is_composite}
+                                    onChange={(e) =>
+                                        toggleComposite(e.target.checked)
+                                    }
+                                    className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+                                />
+                                <span className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-1">
+                                    <IconBoxes size={16} />
+                                    Produk Komposit (bundling /
+                                    paket)
+                                </span>
+                            </label>
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                 <Input
                                     type="number"
@@ -198,22 +269,32 @@ export default function Create({ categories }) {
                                 <Input
                                     type="number"
                                     label="Harga Jual"
-                                    value={data.sell_price}
+                                    value={data.is_composite ? "" : data.sell_price}
+                                    disabled={data.is_composite}
                                     onChange={(e) =>
                                         setData("sell_price", e.target.value)
                                     }
                                     errors={errors.sell_price}
-                                    placeholder="0"
+                                    placeholder={
+                                        data.is_composite
+                                            ? "Otomatis dari komponen"
+                                            : "0"
+                                    }
                                 />
                                 <Input
                                     type="number"
                                     label="Stok"
-                                    value={data.stock}
+                                    value={data.is_composite ? "" : data.stock}
+                                    disabled={data.is_composite}
                                     onChange={(e) =>
                                         setData("stock", e.target.value)
                                     }
                                     errors={errors.stock}
-                                    placeholder="0"
+                                    placeholder={
+                                        data.is_composite
+                                            ? "Dari stok komponen"
+                                            : "0"
+                                    }
                                 />
                             </div>
 
@@ -251,6 +332,118 @@ export default function Create({ categories }) {
                                 </div>
                             )}
                         </div>
+
+                        {/* Composite Components */}
+                        {data.is_composite && (
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+                                <div className="flex items-center justify-between mb-4">
+                                    <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                        <IconBoxes size={18} />
+                                        Komponen Paket
+                                    </h3>
+                                    <button
+                                        type="button"
+                                        onClick={addComponent}
+                                        className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+                                    >
+                                        + Tambah Komponen
+                                    </button>
+                                </div>
+                                {errors.components && (
+                                    <p className="text-sm text-danger-600 mb-2">
+                                        {errors.components}
+                                    </p>
+                                )}
+                                {data.components.length === 0 && (
+                                    <p className="text-sm text-slate-500">
+                                        Belum ada komponen. Stok dan harga jual
+                                        dihitung otomatis dari komponen.
+                                    </p>
+                                )}
+                                <div className="space-y-3">
+                                    {data.components.map((component, index) => (
+                                        <div
+                                            key={index}
+                                            className="flex items-end gap-3"
+                                        >
+                                            <div className="flex-1">
+                                                <InputSelect
+                                                    data={availableProducts(
+                                                        index
+                                                    )}
+                                                    selected={
+                                                        products.find(
+                                                            (p) =>
+                                                                p.id ===
+                                                                Number(
+                                                                    component.component_product_id
+                                                                )
+                                                        ) || null
+                                                    }
+                                                    setSelected={(
+                                                        value
+                                                    ) =>
+                                                        updateComponent(
+                                                            index,
+                                                            "component_product_id",
+                                                            value?.id ?? ""
+                                                        )
+                                                    }
+                                                    placeholder="Pilih produk komponen"
+                                                    errors={
+                                                        errors[
+                                                            `components.${index}.component_product_id`
+                                                        ]
+                                                    }
+                                                    searchable={true}
+                                                    displayKey="title"
+                                                />
+                                            </div>
+                                            <div className="w-28">
+                                                <Input
+                                                    type="number"
+                                                    min="1"
+                                                    value={component.qty}
+                                                    onChange={(e) =>
+                                                        updateComponent(
+                                                            index,
+                                                            "qty",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `components.${index}.qty`
+                                                        ]
+                                                    }
+                                                    placeholder="Qty"
+                                                />
+                                            </div>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    removeComponent(index)
+                                                }
+                                                className="p-2.5 rounded-xl text-danger-600 hover:bg-danger-50 dark:hover:bg-danger-950/30 transition-colors"
+                                            >
+                                                <IconTrash size={18} />
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                                {data.is_composite && estimatedSellPrice > 0 && (
+                                    <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                                        Estimasi harga jual dari komponen:{" "}
+                                        <span className="font-semibold text-slate-700 dark:text-slate-200">
+                                            Rp{" "}
+                                            {estimatedSellPrice.toLocaleString(
+                                                "id-ID"
+                                            )}
+                                        </span>
+                                    </p>
+                                )}
+                            </div>
+                        )}
 
                         {/* Submit */}
                         <div className="flex justify-end gap-3">

--- a/resources/js/Pages/Dashboard/Products/Edit.jsx
+++ b/resources/js/Pages/Dashboard/Products/Edit.jsx
@@ -12,10 +12,12 @@ import {
     IconPhoto,
     IconBarcode,
     IconCurrencyDollar,
+    IconTrash,
+    IconBoxes,
 } from "@tabler/icons-react";
 import { getProductImageUrl } from "@/Utils/imageUrl";
 
-export default function Edit({ categories, product }) {
+export default function Edit({ categories, product, products = [] }) {
     const { errors } = usePage().props;
 
     const { data, setData, post, processing } = useForm({
@@ -27,6 +29,11 @@ export default function Edit({ categories, product }) {
         description: product.description,
         buy_price: product.buy_price,
         sell_price: product.sell_price,
+        is_composite: product.is_composite ?? false,
+        components: (product.components ?? []).map((c) => ({
+            component_product_id: c.id,
+            qty: c.pivot?.qty ?? 1,
+        })),
         _method: "PUT",
     });
 
@@ -48,6 +55,54 @@ export default function Edit({ categories, product }) {
         setData("category_id", value?.id || "");
     };
 
+    const toggleComposite = (checked) => {
+        setData("is_composite", checked);
+    };
+
+    const addComponent = () => {
+        setData("components", [
+            ...data.components,
+            { component_product_id: "", qty: 1 },
+        ]);
+    };
+
+    const updateComponent = (index, field, value) => {
+        const components = data.components.map((c, i) =>
+            i === index ? { ...c, [field]: value } : c
+        );
+        setData("components", components);
+    };
+
+    const removeComponent = (index) => {
+        setData(
+            "components",
+            data.components.filter((_, i) => i !== index)
+        );
+    };
+
+    const availableProducts = (selectedIndex) =>
+        products.filter(
+            (p) =>
+                !p.is_composite &&
+                p.id !== product.id &&
+                !data.components.some(
+                    (c, i) =>
+                        i !== selectedIndex &&
+                        c.component_product_id === p.id
+                )
+        );
+
+    const estimatedSellPrice = data.is_composite
+        ? data.components.reduce((total, c) => {
+              const product = products.find(
+                  (p) => p.id === Number(c.component_product_id)
+              );
+              return product
+                  ? total + product.sell_price * (Number(c.qty) || 0)
+                  : total;
+          }, 0)
+        : data.sell_price;
+
     const handleImageChange = (e) => {
         const file = e.target.files[0];
         if (file) {
@@ -56,8 +111,12 @@ export default function Edit({ categories, product }) {
         }
     };
 
-    const submit = (e) => {
+    // ponytail: zero-out stock/sell_price for composite; collapse if Inertia ever accepts pre-send transforms
+    const submitCompositeAware = (e) => {
         e.preventDefault();
+        if (data.is_composite) {
+            setData("sell_price", 0);
+        }
         post(route("products.update", product.id), {
             onSuccess: () => toast.success("Produk berhasil diperbarui"),
             onError: () => toast.error("Gagal memperbarui produk"),
@@ -83,7 +142,7 @@ export default function Edit({ categories, product }) {
                 <p className="text-sm text-slate-500 mt-1">{product.title}</p>
             </div>
 
-            <form onSubmit={submit}>
+            <form onSubmit={submitCompositeAware}>
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                     {/* Left - Image */}
                     <div className="lg:col-span-1">
@@ -192,6 +251,21 @@ export default function Edit({ categories, product }) {
                                 <IconCurrencyDollar size={18} />
                                 Harga Produk
                             </h3>
+                            <label className="flex items-center gap-2 mb-4 cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={data.is_composite}
+                                    onChange={(e) =>
+                                        toggleComposite(e.target.checked)
+                                    }
+                                    className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+                                />
+                                <span className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-1">
+                                    <IconBoxes size={16} />
+                                    Produk Komposit (bundling /
+                                    paket)
+                                </span>
+                            </label>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <Input
                                     type="number"
@@ -206,21 +280,32 @@ export default function Edit({ categories, product }) {
                                 <Input
                                     type="number"
                                     label="Harga Jual"
-                                    value={data.sell_price}
+                                    value={
+                                        data.is_composite ? "" : data.sell_price
+                                    }
+                                    disabled={data.is_composite}
                                     onChange={(e) =>
                                         setData("sell_price", e.target.value)
                                     }
                                     errors={errors.sell_price}
-                                    placeholder="0"
+                                    placeholder={
+                                        data.is_composite
+                                            ? "Otomatis dari komponen"
+                                            : "0"
+                                    }
                                 />
                             </div>
 
                             <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800">
                                 <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                    Stok Saat Ini
+                                    {data.is_composite
+                                        ? "Stok Komposit"
+                                        : "Stok Saat Ini"}
                                 </p>
                                 <p className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
-                                    {product.stock}
+                                    {data.is_composite
+                                        ? "Dihitung dari stok komponen"
+                                        : product.stock}
                                 </p>
                                 <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                                     Perubahan stok dilakukan melalui transaksi atau stock opname.
@@ -228,7 +313,9 @@ export default function Edit({ categories, product }) {
                             </div>
 
                             {/* Profit Estimation */}
-                            {data.buy_price > 0 && data.sell_price > 0 && (
+                            {!data.is_composite &&
+                                data.buy_price > 0 &&
+                                data.sell_price > 0 && (
                                 <div className="mt-4 p-4 rounded-xl bg-success-50 dark:bg-success-950/30 border border-success-200 dark:border-success-900">
                                     <div className="flex items-center justify-between">
                                         <div>
@@ -258,6 +345,125 @@ export default function Edit({ categories, product }) {
                                             </p>
                                         </div>
                                     </div>
+                                </div>
+                            )}
+
+                            {/* Composite Components */}
+                            {data.is_composite && (
+                                <div className="mt-4">
+                                    <div className="flex items-center justify-between mb-4">
+                                        <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                            <IconBoxes size={18} />
+                                            Komponen Paket
+                                        </h3>
+                                        <button
+                                            type="button"
+                                            onClick={addComponent}
+                                            className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+                                        >
+                                            + Tambah Komponen
+                                        </button>
+                                    </div>
+                                    {errors.components && (
+                                        <p className="text-sm text-danger-600 mb-2">
+                                            {errors.components}
+                                        </p>
+                                    )}
+                                    {data.components.length === 0 && (
+                                        <p className="text-sm text-slate-500">
+                                            Belum ada komponen. Stok dan harga jual
+                                            dihitung otomatis dari komponen.
+                                        </p>
+                                    )}
+                                    <div className="space-y-3">
+                                        {data.components.map(
+                                            (component, index) => (
+                                                <div
+                                                    key={index}
+                                                    className="flex items-end gap-3"
+                                                >
+                                                    <div className="flex-1">
+                                                        <InputSelect
+                                                            data={availableProducts(
+                                                                index
+                                                            )}
+                                                            selected={
+                                                                products.find(
+                                                                    (p) =>
+                                                                        p.id ===
+                                                                        Number(
+                                                                            component.component_product_id
+                                                                        )
+                                                                ) || null
+                                                            }
+                                                            setSelected={(
+                                                                value
+                                                            ) =>
+                                                                updateComponent(
+                                                                    index,
+                                                                    "component_product_id",
+                                                                    value?.id ?? ""
+                                                                )
+                                                            }
+                                                            placeholder="Pilih produk komponen"
+                                                            errors={
+                                                                errors[
+                                                                    `components.${index}.component_product_id`
+                                                                ]
+                                                            }
+                                                            searchable={true}
+                                                            displayKey="title"
+                                                        />
+                                                    </div>
+                                                    <div className="w-28">
+                                                        <Input
+                                                            type="number"
+                                                            min="1"
+                                                            value={
+                                                                component.qty
+                                                            }
+                                                            onChange={(e) =>
+                                                                updateComponent(
+                                                                    index,
+                                                                    "qty",
+                                                                    e.target.value
+                                                                )
+                                                            }
+                                                            errors={
+                                                                errors[
+                                                                    `components.${index}.qty`
+                                                                ]
+                                                            }
+                                                            placeholder="Qty"
+                                                        />
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() =>
+                                                            removeComponent(
+                                                                index
+                                                            )
+                                                        }
+                                                        className="p-2.5 rounded-xl text-danger-600 hover:bg-danger-50 dark:hover:bg-danger-950/30 transition-colors"
+                                                    >
+                                                        <IconTrash size={18} />
+                                                    </button>
+                                                </div>
+                                            )
+                                        )}
+                                    </div>
+                                    {data.is_composite &&
+                                        estimatedSellPrice > 0 && (
+                                            <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                                                Estimasi harga jual dari komponen:{" "}
+                                                <span className="font-semibold text-slate-700 dark:text-slate-200">
+                                                    Rp{" "}
+                                                    {estimatedSellPrice.toLocaleString(
+                                                        "id-ID"
+                                                    )}
+                                                </span>
+                                            </p>
+                                        )}
                                 </div>
                             )}
                         </div>

--- a/resources/js/Pages/Dashboard/Products/Index.jsx
+++ b/resources/js/Pages/Dashboard/Products/Index.jsx
@@ -46,6 +46,7 @@ function ProductCard({
     const rowNumber = index + 1 + (currentPage - 1) * perPage;
     const lowStock = product.stock > 0 && product.stock <= 5;
     const outOfStock = product.stock === 0;
+    const isComposite = product.is_composite;
 
     return (
         <div
@@ -84,7 +85,12 @@ function ProductCard({
                 )}
 
                 {/* Stock Badge */}
-                <div className="absolute top-2 right-2">
+                <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
+                    {isComposite && (
+                        <span className="px-2 py-1 text-xs font-semibold bg-primary-500 text-white rounded-full">
+                            Komposit
+                        </span>
+                    )}
                     {outOfStock ? (
                         <span className="px-2 py-1 text-xs font-semibold bg-danger-500 text-white rounded-full">
                             Habis

--- a/tests/Feature/Products/CompositeProductTest.php
+++ b/tests/Feature/Products/CompositeProductTest.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Cart;
+use App\Models\CashierShift;
+use App\Models\Category;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CompositeProductTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected Warehouse $pusat;
+
+    protected Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+
+        $this->pusat = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Paket Uji',
+            'description' => 'Kategori pengujian',
+            'image' => 'category.png',
+        ]);
+    }
+
+    protected function createComponent(string $title, int $sellPrice = 40000, int $stock = 25): Product
+    {
+        $product = Product::create([
+            'category_id' => $this->category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => $title,
+            'description' => 'Komponen uji.',
+            'buy_price' => 20000,
+            'sell_price' => $sellPrice,
+            'stock' => $stock,
+            'tax_rate' => 0,
+        ]);
+
+        $this->pusat->products()->attach($product->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    protected function createComposite(array $components): Product
+    {
+        $composite = Product::create([
+            'category_id' => $this->category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Paket Hemat',
+            'description' => 'Produk komposit uji.',
+            'buy_price' => 0,
+            'sell_price' => 0,
+            'stock' => 0,
+            'is_composite' => true,
+            'tax_rate' => 0,
+        ]);
+
+        $composite->components()->attach($components);
+
+        return $composite;
+    }
+
+    protected function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'image' => UploadedFile::fake()->image('product.png'),
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Paket Hemat',
+            'description' => 'Produk komposit uji.',
+            'category_id' => $this->category->id,
+            'buy_price' => 0,
+            'sell_price' => 0,
+            'stock' => 0,
+            'is_composite' => '1',
+            'tax_rate' => 0,
+        ], $overrides);
+    }
+
+    public function test_store_creates_composite_with_components(): void
+    {
+        $component = $this->createComponent('Komponen A');
+
+        $this->actingAs($this->admin)
+            ->post(route('products.store'), $this->validPayload([
+                'components' => [
+                    ['component_product_id' => $component->id, 'qty' => 3],
+                ],
+            ]))
+            ->assertRedirect(route('products.index'));
+
+        $composite = Product::where('title', 'Paket Hemat')->firstOrFail();
+
+        $this->assertTrue($composite->is_composite);
+        $this->assertDatabaseHas('composite_product_items', [
+            'composite_product_id' => $composite->id,
+            'component_product_id' => $component->id,
+            'qty' => 3,
+        ]);
+    }
+
+    public function test_store_rejects_composite_without_components(): void
+    {
+        $this->actingAs($this->admin)
+            ->from(route('products.create'))
+            ->post(route('products.store'), $this->validPayload())
+            ->assertSessionHasErrors('components');
+    }
+
+    public function test_store_rejects_composite_component(): void
+    {
+        $composite = $this->createComposite([
+            $this->createComponent('Komponen A')->id => ['qty' => 1],
+        ]);
+
+        $this->actingAs($this->admin)
+            ->post(route('products.store'), $this->validPayload([
+                'title' => 'Paket Bertingkat',
+                'components' => [
+                    ['component_product_id' => $composite->id, 'qty' => 1],
+                ],
+            ]))
+            ->assertStatus(422);
+    }
+
+    public function test_update_rejects_self_referencing_component(): void
+    {
+        $component = $this->createComponent('Komponen A');
+        $composite = $this->createComposite([$component->id => ['qty' => 1]]);
+
+        $this->actingAs($this->admin)
+            ->put(route('products.update', $composite), [
+                'barcode' => $composite->barcode,
+                'sku' => $composite->sku,
+                'title' => $composite->title,
+                'description' => $composite->description,
+                'category_id' => $this->category->id,
+                'buy_price' => 0,
+                'sell_price' => 0,
+                'is_composite' => '1',
+                'components' => [
+                    ['component_product_id' => $composite->id, 'qty' => 1],
+                ],
+            ])
+            ->assertStatus(422);
+    }
+
+    public function test_update_can_convert_product_to_composite(): void
+    {
+        $component = $this->createComponent('Komponen A');
+
+        $product = Product::create([
+            'category_id' => $this->category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Biasa',
+            'description' => 'Produk biasa.',
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 10,
+            'tax_rate' => 0,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->put(route('products.update', $product), [
+                'barcode' => $product->barcode,
+                'sku' => $product->sku,
+                'title' => 'Produk Biasa',
+                'description' => 'Produk biasa.',
+                'category_id' => $this->category->id,
+                'buy_price' => 0,
+                'sell_price' => 0,
+                'is_composite' => '1',
+                'components' => [
+                    ['component_product_id' => $component->id, 'qty' => 2],
+                ],
+            ])
+            ->assertRedirect(route('products.index'));
+
+        $this->assertDatabaseHas('composite_product_items', [
+            'composite_product_id' => $product->id,
+            'component_product_id' => $component->id,
+            'qty' => 2,
+        ]);
+        $this->assertTrue($product->fresh()->is_composite);
+    }
+
+    public function test_update_cannot_remove_all_components_from_composite(): void
+    {
+        $component = $this->createComponent('Komponen A');
+        $composite = $this->createComposite([$component->id => ['qty' => 1]]);
+
+        $this->actingAs($this->admin)
+            ->from(route('products.edit', $composite))
+            ->put(route('products.update', $composite), [
+                'barcode' => $composite->barcode,
+                'sku' => $composite->sku,
+                'title' => $composite->title,
+                'description' => $composite->description,
+                'category_id' => $this->category->id,
+                'buy_price' => 0,
+                'sell_price' => 0,
+                'is_composite' => '1',
+                'components' => [],
+            ])
+            ->assertSessionHasErrors('components');
+    }
+
+    public function test_composite_checkout_decrements_component_stock(): void
+    {
+        $cashier = User::factory()->create();
+        $cashier->givePermissionTo([
+            'transactions-access',
+            'cashier-shifts-access',
+            'cashier-shifts-open',
+            'cashier-shifts-close',
+        ]);
+
+        $shift = CashierShift::create([
+            'user_id' => $cashier->id,
+            'opened_by' => $cashier->id,
+            'opened_at' => now(),
+            'opening_cash' => 100000,
+            'expected_cash' => 100000,
+            'status' => 'open',
+            'warehouse_id' => $this->pusat->id,
+        ]);
+
+        $componentA = $this->createComponent('Komponen A', 60000, 25);
+        $componentB = $this->createComponent('Komponen B', 40000, 25);
+        $composite = $this->createComposite([
+            $componentA->id => ['qty' => 2],
+            $componentB->id => ['qty' => 1],
+        ]);
+
+        $customer = Customer::create([
+            'name' => 'Pembeli Paket',
+            'no_telp' => 62812345,
+            'address' => 'Jl. Uji No. 1',
+        ]);
+
+        // Add composite to cart via POS flow (price = sum of components)
+        $this->actingAs($cashier)
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $composite->id,
+                'qty' => 1,
+            ])
+            ->assertRedirect(route('transactions.index'));
+
+        $cart = Cart::where('cashier_id', $cashier->id)->where('product_id', $composite->id)->firstOrFail();
+        $this->assertSame(160000, (int) $cart->price);
+
+        $response = $this->actingAs($cashier)
+            ->post(route('transactions.store'), [
+                'customer_id' => $customer->id,
+                'discount' => 0,
+                'grand_total' => $cart->price,
+                'cash' => 200000,
+                'change' => 40000,
+            ]);
+
+        $transaction = Transaction::latest('id')->first();
+        $response->assertRedirect(route('transactions.print', $transaction->invoice));
+
+        $this->assertSame(1, $transaction->details->count());
+        $this->assertSame($composite->id, $transaction->details->first()->product_id);
+        $this->assertSame(160000, (int) $transaction->details->first()->price);
+
+        // Component stock decremented (global + warehouse pivot)
+        $this->assertSame(23, $componentA->fresh()->stock);
+        $this->assertSame(24, $componentB->fresh()->stock);
+        $this->assertSame(23, (int) $componentA->fresh()->warehouses()->where('warehouse_id', $this->pusat->id)->first()->pivot->stock);
+        $this->assertSame(24, (int) $componentB->fresh()->warehouses()->where('warehouse_id', $this->pusat->id)->first()->pivot->stock);
+
+        // Composite itself has no stock of its own
+        $this->assertSame(0, $composite->fresh()->stock);
+    }
+}


### PR DESCRIPTION
## Summary
- Completes the composite-products feature: checkout logic existed but products could not be defined as composites
- ProductController validates `is_composite` + `components` (1-level nesting guard, no self-reference), syncs `composite_product_items`
- Products Create/Edit: composite toggle + component repeater, price/stock auto-derived; composite badge in Index
- Fixes pre-existing bugs found by tests: undefined $unitId on composite add-to-cart (web POS 500), PricingService::buildPreview computing 0 price for composite lines
- 7 new feature tests incl. end-to-end checkout decrementing component stock

## Test plan
- `php artisan test` — 161 passed (760 assertions), no regressions