### PR TITLE
feat(units): unit management and multi-unit POS sales

### DIFF
--- a/app/Http/Controllers/Apps/ProductController.php
+++ b/app/Http/Controllers/Apps/ProductController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Apps;
 use App\Http\Controllers\Controller;
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\Unit;
 use App\Models\Warehouse;
 use App\Services\AuditLogService;
 use App\Services\StockMutationService;
@@ -58,6 +59,7 @@ class ProductController extends Controller
         return Inertia::render('Dashboard/Products/Create', [
             'categories' => $categories,
             'products' => $products,
+            'units' => Unit::orderBy('code')->get(['id', 'code', 'symbol']),
         ]);
     }
 
@@ -83,6 +85,7 @@ class ProductController extends Controller
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
             ...$this->compositeRules(),
+            ...$this->unitRules(),
         ]);
         // upload image
         $image = $request->file('image');
@@ -108,6 +111,7 @@ class ProductController extends Controller
             $this->validateComponentProducts($request);
             $this->syncComponents($product, $request->input('components'));
         } else {
+            $this->syncUnits($product, $request->input('units'));
             $this->stockMutationService->recordInitialStock($product, $request->user()?->id);
         }
         $this->auditLogService->log(
@@ -140,9 +144,10 @@ class ProductController extends Controller
             ->get(['id', 'title', 'sell_price', 'is_composite']);
 
         return Inertia::render('Dashboard/Products/Edit', [
-            'product' => $product->load('components'),
+            'product' => $product->load('components', 'units'),
             'categories' => $categories,
             'products' => $products,
+            'units' => Unit::orderBy('code')->get(['id', 'code', 'symbol']),
         ]);
     }
 
@@ -170,6 +175,7 @@ class ProductController extends Controller
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
             ...$this->compositeRules(),
+            ...$this->unitRules(),
         ]);
 
         if ($request->boolean('is_composite')) {
@@ -205,6 +211,8 @@ class ProductController extends Controller
 
             if ($request->boolean('is_composite')) {
                 $this->syncComponents($product, $request->input('components'));
+            } else {
+                $this->syncUnits($product, $request->input('units'));
             }
 
             $this->logProductUpdate($product, $before);
@@ -226,6 +234,8 @@ class ProductController extends Controller
 
         if ($request->boolean('is_composite')) {
             $this->syncComponents($product, $request->input('components'));
+        } else {
+            $this->syncUnits($product, $request->input('units'));
         }
 
         $this->logProductUpdate($product, $before);
@@ -298,6 +308,59 @@ class ProductController extends Controller
                 $c['component_product_id'] => ['qty' => (int) $c['qty']],
             ])
         );
+    }
+
+    private function unitRules(): array
+    {
+        return [
+            'units' => 'nullable|array',
+            'units.*.unit_id' => 'required|integer|distinct|exists:units,id',
+            'units.*.is_base' => 'required|boolean',
+            'units.*.conversion_factor' => 'required|numeric|min:0.0001',
+            'units.*.buy_price' => 'nullable|integer|min:0',
+            'units.*.sell_price' => 'nullable|integer|min:0',
+            'units.*.barcode' => 'nullable|string|max:255',
+        ];
+    }
+
+    private function syncUnits(Product $product, ?array $units): void
+    {
+        $rows = collect($units ?? [])
+            ->keyBy('unit_id')
+            ->map(fn (array $u) => [
+                'is_base' => $u['is_base'],
+                'conversion_factor' => $u['conversion_factor'],
+                'buy_price' => $u['buy_price'] ?? $product->buy_price,
+                'sell_price' => $u['sell_price'] ?? $product->sell_price,
+                'barcode' => $u['barcode'] ?? null,
+            ]);
+
+        if ($rows->isEmpty()) {
+            // ponytail: no units sent — only seed default PCS base when product has none (matches docs/features/unit-conversion.md)
+            if ($product->units()->exists()) {
+                return;
+            }
+
+            $pcs = Unit::where('code', 'PCS')->first();
+            if ($pcs) {
+                $product->units()->attach($pcs->id, [
+                    'is_base' => true,
+                    'conversion_factor' => 1,
+                    'buy_price' => $product->buy_price,
+                    'sell_price' => $product->sell_price,
+                ]);
+            }
+
+            return;
+        }
+
+        if (! $rows->contains(fn ($r) => $r['is_base'])) {
+            // ponytail: no explicit base unit sent — treat first row as base with factor 1
+            $first = $rows->keys()->first();
+            $rows[$first] = ['is_base' => true, 'conversion_factor' => 1] + $rows[$first];
+        }
+
+        $product->units()->sync($rows->all());
     }
 
     private function logProductUpdate(Product $product, array $before): void

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -86,7 +86,7 @@ class TransactionController extends Controller
         $customers = Customer::latest()->get();
 
         // get products with stock > 0 in active warehouse
-        $products = Product::with('category:id,name')
+        $products = Product::with(['category:id,name', 'units'])
             ->select('id', 'barcode', 'title', 'description', 'image', 'buy_price', 'sell_price', 'stock', 'category_id')
             ->when($warehouseId, function ($q) use ($warehouseId) {
                 $q->whereHas('warehouses', fn ($w) => $w->where('product_warehouse.warehouse_id', $warehouseId)
@@ -102,6 +102,14 @@ class TransactionController extends Controller
 
             return [
                 ...$product->toArray(),
+                'units' => $product->units->map(fn ($u) => [
+                    'unit_id' => $u->id,
+                    'code' => $u->code,
+                    'is_base' => (bool) $u->pivot->is_base,
+                    'conversion_factor' => (float) $u->pivot->conversion_factor,
+                    'sell_price' => (int) $u->pivot->sell_price,
+                    'barcode' => $u->pivot->barcode,
+                ]),
                 'pricing_badge' => $pricing && ! empty($pricing['pricing_rule']) ? [
                     'label' => $pricing['pricing_rule']['label'],
                     'promo_price' => $pricing['pricing_rule']['price_context']

--- a/app/Http/Controllers/Apps/UnitController.php
+++ b/app/Http/Controllers/Apps/UnitController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Apps;
+
+use App\Http\Controllers\Controller;
+use App\Models\Unit;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+
+class UnitController extends Controller
+{
+    public function index()
+    {
+        $units = Unit::withCount('products')->orderBy('code')->get();
+
+        return Inertia::render('Dashboard/Settings/Units', [
+            'units' => $units,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'code' => ['required', 'string', 'max:10', 'unique:units,code'],
+            'name' => ['required', 'string', 'max:50'],
+            'symbol' => ['required', 'string', 'max:10'],
+        ]);
+
+        Unit::create($validated);
+
+        return back()->with('success', 'Satuan berhasil ditambahkan.');
+    }
+
+    public function update(Request $request, Unit $unit)
+    {
+        $validated = $request->validate([
+            'code' => ['required', 'string', 'max:10', Rule::unique('units', 'code')->ignore($unit->id)],
+            'name' => ['required', 'string', 'max:50'],
+            'symbol' => ['required', 'string', 'max:10'],
+        ]);
+
+        $unit->update($validated);
+
+        return back()->with('success', 'Satuan berhasil diperbarui.');
+    }
+
+    public function destroy(Unit $unit)
+    {
+        if ($unit->products()->exists()) {
+            return back()->with('error', 'Satuan masih dipakai produk. Lepaskan dari produk terlebih dahulu.');
+        }
+
+        $unit->delete();
+
+        return back()->with('success', 'Satuan berhasil dihapus.');
+    }
+}

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -7,4 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class Unit extends Model
 {
     protected $fillable = ['code', 'name', 'symbol'];
+
+    public function products()
+    {
+        return $this->belongsToMany(Product::class, 'product_units')
+            ->using(ProductUnit::class)
+            ->withPivot(['is_base', 'conversion_factor', 'buy_price', 'sell_price', 'barcode', 'sku_suffix']);
+    }
 }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -155,6 +155,12 @@ class PermissionSeeder extends Seeder
         $create('warehouses-update');
         $create('warehouses-delete');
 
+        // units
+        $create('units-access');
+        $create('units-create');
+        $create('units-update');
+        $create('units-delete');
+
         // whatsapp
         $create('whatsapp-settings-access');
         $create('whatsapp-settings-update');

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -56,6 +56,7 @@ class RoleSeeder extends Seeder
         $this->createRoleWithPermissions('discounts-approve', 'discounts-approve');
         $this->createRoleWithPermissions('price-lists-access', '%price-lists%');
         $this->createRoleWithPermissions('warehouses-access', '%warehouses%');
+        $this->createRoleWithPermissions('units-access', '%units%');
 
         $this->createRoleWithPermissions('dine-tables-access', '%dine-tables%');
         $this->createRoleWithPermissions('dine-orders-access', '%dine-orders%');

--- a/resources/js/Components/POS/ProductGrid.jsx
+++ b/resources/js/Components/POS/ProductGrid.jsx
@@ -23,22 +23,40 @@ function ProductCard({ product, onAddToCart, isAdding }) {
     const basePrice = Number(promoBadge?.base_price || product.sell_price || 0);
     const showPromo = promoBadge && promoPrice > 0 && promoPrice < basePrice;
     const showBadge = Boolean(promoBadge?.label);
+    const multiUnits = (product.units || []).filter(
+        (u) => !u.is_base
+    );
+    const [selectedUnitId, setSelectedUnitId] = React.useState(null);
+    const selectedUnit =
+        multiUnits.find((u) => u.unit_id === selectedUnitId) || null;
+    const displayPrice = selectedUnit
+        ? selectedUnit.sell_price
+        : showPromo
+          ? promoPrice
+          : product.sell_price;
 
     return (
-        <button
-            onClick={() => hasStock && onAddToCart(product)}
-            disabled={!hasStock || isAdding}
+        <div
             className={`
                 group relative flex flex-col bg-white dark:bg-slate-900
                 rounded-2xl border border-slate-200 dark:border-slate-800
                 overflow-hidden transition-all duration-200
                 ${
                     hasStock
-                        ? "hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg hover:-translate-y-0.5 active:scale-[0.98] cursor-pointer"
-                        : "opacity-60 cursor-not-allowed"
+                        ? "hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg hover:-translate-y-0.5 active:scale-[0.98]"
+                        : "opacity-60"
                 }
             `}
         >
+            {/* Product Image — click adds base unit */}
+            <button
+                type="button"
+                onClick={() => hasStock && onAddToCart(product, selectedUnit)}
+                disabled={!hasStock || isAdding}
+                className={`block text-left ${
+                    hasStock ? "cursor-pointer" : "cursor-not-allowed"
+                }`}
+            >
             {/* Product Image */}
             <div className="relative aspect-square bg-slate-100 dark:bg-slate-800 overflow-hidden">
                 {product.image ? (
@@ -88,6 +106,7 @@ function ProductCard({ product, onAddToCart, isAdding }) {
                     </div>
                 )}
             </div>
+            </button>
 
             {/* Product Info */}
             <div className="flex-1 p-3 flex flex-col justify-between min-h-[80px]">
@@ -95,23 +114,57 @@ function ProductCard({ product, onAddToCart, isAdding }) {
                     {product.title}
                 </h3>
                 <div className="mt-2">
-                    {showPromo && (
+                    {showPromo && !selectedUnit && (
                         <p className="text-xs text-slate-400 line-through">
                             {formatPrice(basePrice)}
                         </p>
                     )}
                     <p className="text-base font-bold text-primary-600 dark:text-primary-400">
-                        {formatPrice(showPromo ? promoPrice : product.sell_price)}
+                        {formatPrice(displayPrice)}
+                        {selectedUnit && (
+                            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                                {" "}/{selectedUnit.code}
+                            </span>
+                        )}
                     </p>
-                    {showBadge && !showPromo && (
+                    {showBadge && !showPromo && !selectedUnit && (
                         <p className="mt-1 text-[11px] text-slate-500 dark:text-slate-400">
                             Promo tersedia
                         </p>
                     )}
+                    {multiUnits.length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                            <button
+                                type="button"
+                                onClick={() => setSelectedUnitId(null)}
+                                className={`px-1.5 py-0.5 rounded-md text-[10px] font-medium border transition-colors ${
+                                    selectedUnit === null
+                                        ? "bg-primary-500 text-white border-primary-500"
+                                        : "border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
+                                }`}
+                            >
+                                Dasar
+                            </button>
+                            {multiUnits.map((u) => (
+                                <button
+                                    key={u.unit_id}
+                                    type="button"
+                                    onClick={() => setSelectedUnitId(u.unit_id)}
+                                    className={`px-1.5 py-0.5 rounded-md text-[10px] font-medium border transition-colors ${
+                                        selectedUnitId === u.unit_id
+                                            ? "bg-primary-500 text-white border-primary-500"
+                                            : "border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
+                                    }`}
+                                >
+                                    {u.code}
+                                </button>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
 
-        </button>
+        </div>
     );
 }
 

--- a/resources/js/Pages/Dashboard/Products/Create.jsx
+++ b/resources/js/Pages/Dashboard/Products/Create.jsx
@@ -14,10 +14,11 @@ import {
     IconBarcode,
     IconCurrencyDollar,
     IconTrash,
-    IconBoxes,
+    IconPackages,
+    IconRulerMeasure,
 } from "@tabler/icons-react";
 
-export default function Create({ categories, products }) {
+export default function Create({ categories, products, units = [] }) {
     const { errors } = usePage().props;
 
     const { data, setData, post, processing } = useForm({
@@ -32,6 +33,7 @@ export default function Create({ categories, products }) {
         stock: "",
         is_composite: false,
         components: [],
+        units: [],
     });
 
     const [selectedCategory, setSelectedCategory] = useState(null);
@@ -44,7 +46,49 @@ export default function Create({ categories, products }) {
 
     const toggleComposite = (checked) => {
         setData("is_composite", checked);
+        if (checked) setData("units", []);
     };
+
+    const addUnitRow = () => {
+        const firstUnused = units.find(
+            (u) => !data.units.some((row) => row.unit_id === u.id)
+        );
+        if (!firstUnused) return;
+        setData("units", [
+            ...data.units,
+            {
+                unit_id: firstUnused.id,
+                is_base: data.units.length === 0,
+                conversion_factor: data.units.length === 0 ? 1 : "",
+                sell_price: "",
+                barcode: "",
+            },
+        ]);
+    };
+
+    const updateUnitRow = (index, field, value) => {
+        const rows = data.units.map((r, i) =>
+            i === index ? { ...r, [field]: value } : r
+        );
+        if (field === "is_base" && value) {
+            rows.forEach((r, i) => {
+                if (i !== index) r.is_base = false;
+            });
+        }
+        setData("units", rows);
+    };
+
+    const removeUnitRow = (index) => {
+        setData("units", data.units.filter((_, i) => i !== index));
+    };
+
+    const availableUnits = (selectedIndex) =>
+        units.filter(
+            (u) =>
+                !data.units.some(
+                    (r, i) => i !== selectedIndex && r.unit_id === u.id
+                )
+        );
 
     const addComponent = () => {
         setData("components", [
@@ -250,7 +294,7 @@ export default function Create({ categories, products }) {
                                     className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
                                 />
                                 <span className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-1">
-                                    <IconBoxes size={16} />
+                                    <IconPackages size={16} />
                                     Produk Komposit (bundling /
                                     paket)
                                 </span>
@@ -333,12 +377,169 @@ export default function Create({ categories, products }) {
                             )}
                         </div>
 
+                        {/* Units */}
+                        {!data.is_composite && (
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+                                <div className="flex items-center justify-between mb-4">
+                                    <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                        <IconRulerMeasure size={18} />
+                                        Satuan
+                                    </h3>
+                                    <button
+                                        type="button"
+                                        onClick={addUnitRow}
+                                        disabled={
+                                            data.units.length >= units.length
+                                        }
+                                        className="text-sm text-primary-600 hover:text-primary-700 font-medium disabled:opacity-40"
+                                    >
+                                        + Tambah Satuan
+                                    </button>
+                                </div>
+                                {errors.units && (
+                                    <p className="text-sm text-danger-600 mb-2">
+                                        {errors.units}
+                                    </p>
+                                )}
+                                {data.units.length === 0 && (
+                                    <p className="text-sm text-slate-500">
+                                        Satuan dasar otomatis dibuat jika tidak
+                                        ditambahkan. Tambahkan satuan (box, kg,
+                                        dll) untuk penjualan multi-satuan.
+                                    </p>
+                                )}
+                                <div className="space-y-3">
+                                    {data.units.map((row, index) => (
+                                        <div
+                                            key={index}
+                                            className="flex items-end gap-3"
+                                        >
+                                            <div className="flex-1">
+                                                <InputSelect
+                                                    data={availableUnits(index)}
+                                                    selected={
+                                                        units.find(
+                                                            (u) =>
+                                                                u.id ===
+                                                                row.unit_id
+                                                        ) || null
+                                                    }
+                                                    setSelected={(value) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "unit_id",
+                                                            value?.id ?? ""
+                                                        )
+                                                    }
+                                                    placeholder="Pilih satuan"
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.unit_id`
+                                                        ]
+                                                    }
+                                                    searchable={true}
+                                                    displayKey="code"
+                                                />
+                                            </div>
+                                            <div className="w-36">
+                                                <Input
+                                                    type="number"
+                                                    min="0.0001"
+                                                    step="0.0001"
+                                                    value={
+                                                        row.conversion_factor
+                                                    }
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "conversion_factor",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.conversion_factor`
+                                                        ]
+                                                    }
+                                                    placeholder="Konversi"
+                                                    disabled={row.is_base}
+                                                />
+                                            </div>
+                                            <div className="w-40">
+                                                <Input
+                                                    type="number"
+                                                    min="0"
+                                                    value={row.sell_price}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "sell_price",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.sell_price`
+                                                        ]
+                                                    }
+                                                    placeholder="Harga jual"
+                                                />
+                                            </div>
+                                            <div className="w-44">
+                                                <Input
+                                                    type="text"
+                                                    value={row.barcode}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "barcode",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.barcode`
+                                                        ]
+                                                    }
+                                                    placeholder="Barcode (opsional)"
+                                                />
+                                            </div>
+                                            <label className="flex items-center gap-1 pb-3 text-xs text-slate-600 dark:text-slate-300 whitespace-nowrap">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={row.is_base}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "is_base",
+                                                            e.target.checked
+                                                        )
+                                                    }
+                                                    className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+                                                />
+                                                Dasar
+                                            </label>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    removeUnitRow(index)
+                                                }
+                                                className="p-2.5 rounded-xl text-danger-600 hover:bg-danger-50 dark:hover:bg-danger-950/30 transition-colors"
+                                            >
+                                                <IconTrash size={18} />
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
                         {/* Composite Components */}
                         {data.is_composite && (
                             <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
                                 <div className="flex items-center justify-between mb-4">
                                     <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                        <IconBoxes size={18} />
+                                        <IconPackages size={18} />
                                         Komponen Paket
                                     </h3>
                                     <button

--- a/resources/js/Pages/Dashboard/Products/Edit.jsx
+++ b/resources/js/Pages/Dashboard/Products/Edit.jsx
@@ -13,11 +13,12 @@ import {
     IconBarcode,
     IconCurrencyDollar,
     IconTrash,
-    IconBoxes,
+    IconPackages,
+    IconRulerMeasure,
 } from "@tabler/icons-react";
 import { getProductImageUrl } from "@/Utils/imageUrl";
 
-export default function Edit({ categories, product, products = [] }) {
+export default function Edit({ categories, product, products = [], units = [] }) {
     const { errors } = usePage().props;
 
     const { data, setData, post, processing } = useForm({
@@ -33,6 +34,13 @@ export default function Edit({ categories, product, products = [] }) {
         components: (product.components ?? []).map((c) => ({
             component_product_id: c.id,
             qty: c.pivot?.qty ?? 1,
+        })),
+        units: (product.units ?? []).map((u) => ({
+            unit_id: u.id,
+            is_base: !!u.pivot?.is_base,
+            conversion_factor: u.pivot?.conversion_factor ?? 1,
+            sell_price: u.pivot?.sell_price ?? "",
+            barcode: u.pivot?.barcode ?? "",
         })),
         _method: "PUT",
     });
@@ -57,7 +65,49 @@ export default function Edit({ categories, product, products = [] }) {
 
     const toggleComposite = (checked) => {
         setData("is_composite", checked);
+        if (checked) setData("units", []);
     };
+
+    const addUnitRow = () => {
+        const firstUnused = units.find(
+            (u) => !data.units.some((row) => row.unit_id === u.id)
+        );
+        if (!firstUnused) return;
+        setData("units", [
+            ...data.units,
+            {
+                unit_id: firstUnused.id,
+                is_base: data.units.length === 0,
+                conversion_factor: data.units.length === 0 ? 1 : "",
+                sell_price: "",
+                barcode: "",
+            },
+        ]);
+    };
+
+    const updateUnitRow = (index, field, value) => {
+        const rows = data.units.map((r, i) =>
+            i === index ? { ...r, [field]: value } : r
+        );
+        if (field === "is_base" && value) {
+            rows.forEach((r, i) => {
+                if (i !== index) r.is_base = false;
+            });
+        }
+        setData("units", rows);
+    };
+
+    const removeUnitRow = (index) => {
+        setData("units", data.units.filter((_, i) => i !== index));
+    };
+
+    const availableUnits = (selectedIndex) =>
+        units.filter(
+            (u) =>
+                !data.units.some(
+                    (r, i) => i !== selectedIndex && r.unit_id === u.id
+                )
+        );
 
     const addComponent = () => {
         setData("components", [
@@ -246,6 +296,163 @@ export default function Edit({ categories, product, products = [] }) {
                             </div>
                         </div>
 
+                        {/* Units */}
+                        {!data.is_composite && (
+                            <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
+                                <div className="flex items-center justify-between mb-4">
+                                    <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                        <IconRulerMeasure size={18} />
+                                        Satuan
+                                    </h3>
+                                    <button
+                                        type="button"
+                                        onClick={addUnitRow}
+                                        disabled={
+                                            data.units.length >= units.length
+                                        }
+                                        className="text-sm text-primary-600 hover:text-primary-700 font-medium disabled:opacity-40"
+                                    >
+                                        + Tambah Satuan
+                                    </button>
+                                </div>
+                                {errors.units && (
+                                    <p className="text-sm text-danger-600 mb-2">
+                                        {errors.units}
+                                    </p>
+                                )}
+                                {data.units.length === 0 && (
+                                    <p className="text-sm text-slate-500">
+                                        Satuan dasar otomatis dibuat jika tidak
+                                        ditambahkan. Tambahkan satuan (box, kg,
+                                        dll) untuk penjualan multi-satuan.
+                                    </p>
+                                )}
+                                <div className="space-y-3">
+                                    {data.units.map((row, index) => (
+                                        <div
+                                            key={index}
+                                            className="flex items-end gap-3"
+                                        >
+                                            <div className="flex-1">
+                                                <InputSelect
+                                                    data={availableUnits(index)}
+                                                    selected={
+                                                        units.find(
+                                                            (u) =>
+                                                                u.id ===
+                                                                row.unit_id
+                                                        ) || null
+                                                    }
+                                                    setSelected={(value) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "unit_id",
+                                                            value?.id ?? ""
+                                                        )
+                                                    }
+                                                    placeholder="Pilih satuan"
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.unit_id`
+                                                        ]
+                                                    }
+                                                    searchable={true}
+                                                    displayKey="code"
+                                                />
+                                            </div>
+                                            <div className="w-36">
+                                                <Input
+                                                    type="number"
+                                                    min="0.0001"
+                                                    step="0.0001"
+                                                    value={
+                                                        row.conversion_factor
+                                                    }
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "conversion_factor",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.conversion_factor`
+                                                        ]
+                                                    }
+                                                    placeholder="Konversi"
+                                                    disabled={row.is_base}
+                                                />
+                                            </div>
+                                            <div className="w-40">
+                                                <Input
+                                                    type="number"
+                                                    min="0"
+                                                    value={row.sell_price}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "sell_price",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.sell_price`
+                                                        ]
+                                                    }
+                                                    placeholder="Harga jual"
+                                                />
+                                            </div>
+                                            <div className="w-44">
+                                                <Input
+                                                    type="text"
+                                                    value={row.barcode}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "barcode",
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    errors={
+                                                        errors[
+                                                            `units.${index}.barcode`
+                                                        ]
+                                                    }
+                                                    placeholder="Barcode (opsional)"
+                                                />
+                                            </div>
+                                            <label className="flex items-center gap-1 pb-3 text-xs text-slate-600 dark:text-slate-300 whitespace-nowrap">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={row.is_base}
+                                                    onChange={(e) =>
+                                                        updateUnitRow(
+                                                            index,
+                                                            "is_base",
+                                                            e.target.checked
+                                                        )
+                                                    }
+                                                    className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+                                                />
+                                                Dasar
+                                            </label>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    removeUnitRow(index)
+                                                }
+                                                className="p-2.5 rounded-xl text-danger-600 hover:bg-danger-50 dark:hover:bg-danger-950/30 transition-colors"
+                                            >
+                                                <IconTrash size={18} />
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
                         <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-5">
                             <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-4 flex items-center gap-2">
                                 <IconCurrencyDollar size={18} />
@@ -261,7 +468,7 @@ export default function Edit({ categories, product, products = [] }) {
                                     className="rounded border-slate-300 text-primary-600 focus:ring-primary-500"
                                 />
                                 <span className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-1">
-                                    <IconBoxes size={16} />
+                                    <IconPackages size={16} />
                                     Produk Komposit (bundling /
                                     paket)
                                 </span>
@@ -353,7 +560,7 @@ export default function Edit({ categories, product, products = [] }) {
                                 <div className="mt-4">
                                     <div className="flex items-center justify-between mb-4">
                                         <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                            <IconBoxes size={18} />
+                                            <IconPackages size={18} />
                                             Komponen Paket
                                         </h3>
                                         <button

--- a/resources/js/Pages/Dashboard/Settings/Units.jsx
+++ b/resources/js/Pages/Dashboard/Settings/Units.jsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useState } from "react";
+import { Head, usePage, router } from "@inertiajs/react";
+import DashboardLayout from "@/Layouts/DashboardLayout";
+import {
+    IconRulerMeasure,
+    IconPlus,
+    IconPencil,
+    IconTrash,
+} from "@tabler/icons-react";
+import toast from "react-hot-toast";
+import { useAuthorization } from "@/Utils/authorization";
+import Input from "@/Components/Dashboard/Input";
+
+export default function Units({ units = [] }) {
+    const { flash } = usePage().props;
+    const { can } = useAuthorization();
+    const canCreate = can("units-create");
+    const canUpdate = can("units-update");
+    const canDelete = can("units-delete");
+
+    const [showForm, setShowForm] = useState(false);
+    const [editing, setEditing] = useState(null);
+    const [form, setForm] = useState({ code: "", name: "", symbol: "" });
+    const [errors, setErrors] = useState({});
+
+    useEffect(() => {
+        if (flash?.success) toast.success(flash.success);
+        if (flash?.error) toast.error(flash.error);
+    }, [flash]);
+
+    const resetForm = () => {
+        setForm({ code: "", name: "", symbol: "" });
+        setErrors({});
+        setEditing(null);
+        setShowForm(false);
+    };
+
+    const openEdit = (u) => {
+        setEditing(u);
+        setForm({ code: u.code, name: u.name, symbol: u.symbol });
+        setErrors({});
+        setShowForm(true);
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setErrors({});
+
+        if (editing) {
+            router.put(route("settings.units.update", editing.id), form, {
+                onError: (err) => setErrors(err),
+                onSuccess: () => resetForm(),
+            });
+        } else {
+            router.post(route("settings.units.store"), form, {
+                onError: (err) => setErrors(err),
+                onSuccess: () => resetForm(),
+            });
+        }
+    };
+
+    const handleDelete = (u) => {
+        if (!confirm(`Hapus satuan ${u.name}?`)) return;
+        router.delete(route("settings.units.destroy", u.id));
+    };
+
+    return (
+        <>
+            <Head title="Pengaturan Satuan" />
+
+            <div className="mb-6">
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+                    <IconRulerMeasure size={28} className="text-primary-500" />
+                    Satuan
+                </h1>
+                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                    Master satuan produk (pcs, box, karton, dll) untuk penjualan multi-satuan
+                </p>
+            </div>
+
+            <div className="max-w-4xl space-y-6">
+                <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+                    <div className="p-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
+                        <h3 className="font-semibold text-slate-800 dark:text-white">
+                            Daftar Satuan ({units.length})
+                        </h3>
+                        {canCreate && (
+                            <button
+                                onClick={() => { resetForm(); setShowForm(true); }}
+                                className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium transition-colors"
+                            >
+                                <IconPlus size={18} />
+                                Tambah Satuan
+                            </button>
+                        )}
+                    </div>
+
+                    {units.length > 0 ? (
+                        <div className="divide-y divide-slate-200 dark:divide-slate-800">
+                            {units.map((u) => (
+                                <div key={u.id} className="p-4 flex items-center gap-4">
+                                    <div className="w-10 h-10 rounded-xl bg-slate-100 dark:bg-slate-800 flex items-center justify-center">
+                                        <IconRulerMeasure size={22} className="text-slate-500" />
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2">
+                                            <p className="font-semibold text-slate-800 dark:text-white truncate">
+                                                {u.name}
+                                            </p>
+                                            <span className="px-2 py-0.5 rounded-lg text-xs font-medium bg-accent-100 text-accent-700 dark:bg-accent-900/30 dark:text-accent-400">
+                                                {u.symbol}
+                                            </span>
+                                        </div>
+                                        <p className="text-sm text-slate-500 dark:text-slate-400">
+                                            {u.code}
+                                            {u.products_count > 0
+                                                ? ` • dipakai ${u.products_count} produk`
+                                                : ""}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center gap-2 shrink-0">
+                                        {canUpdate && (
+                                            <button
+                                                onClick={() => openEdit(u)}
+                                                className="p-2 rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                                            >
+                                                <IconPencil size={18} />
+                                            </button>
+                                        )}
+                                        {canDelete && u.products_count === 0 && (
+                                            <button
+                                                onClick={() => handleDelete(u)}
+                                                className="p-2 rounded-lg text-danger-500 hover:bg-danger-50 dark:hover:bg-danger-900/20 transition-colors"
+                                            >
+                                                <IconTrash size={18} />
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="p-8 text-center">
+                            <IconRulerMeasure size={48} className="mx-auto text-slate-300 dark:text-slate-600 mb-3" />
+                            <p className="text-slate-500 dark:text-slate-400">Belum ada satuan</p>
+                        </div>
+                    )}
+                </div>
+
+                {showForm && (
+                    <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 p-4 space-y-4">
+                        <h3 className="font-semibold text-slate-800 dark:text-white">
+                            {editing ? "Edit Satuan" : "Tambah Satuan Baru"}
+                        </h3>
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                <Input
+                                    label="Kode"
+                                    placeholder="PCS"
+                                    value={form.code}
+                                    onChange={(e) => setForm({ ...form, code: e.target.value })}
+                                    errors={errors.code}
+                                />
+                                <Input
+                                    label="Nama Satuan"
+                                    placeholder="Pieces"
+                                    value={form.name}
+                                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                                    errors={errors.name}
+                                />
+                                <Input
+                                    label="Simbol"
+                                    placeholder="pcs"
+                                    value={form.symbol}
+                                    onChange={(e) => setForm({ ...form, symbol: e.target.value })}
+                                    errors={errors.symbol}
+                                />
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    type="submit"
+                                    className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-primary-500 hover:bg-primary-600 text-white text-sm font-semibold transition-colors"
+                                >
+                                    {editing ? "Update" : "Simpan"}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={resetForm}
+                                    className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                                >
+                                    Batal
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}
+
+Units.layout = (page) => <DashboardLayout children={page} />;

--- a/resources/js/Pages/Dashboard/Transactions/Index.jsx
+++ b/resources/js/Pages/Dashboard/Transactions/Index.jsx
@@ -313,7 +313,7 @@ export default function Index({
     };
 
     // Handle add product to cart
-    const handleAddToCart = async (product) => {
+    const handleAddToCart = async (product, unit = null) => {
         if (!product?.id) return;
 
         setAddingProductId(product.id);
@@ -322,13 +322,14 @@ export default function Index({
             route("transactions.addToCart"),
             {
                 product_id: product.id,
-                sell_price: product.sell_price,
+                sell_price: unit ? unit.sell_price : product.sell_price,
                 qty: 1,
+                unit_id: unit ? unit.unit_id : undefined,
             },
             {
                 preserveScroll: true,
                 onSuccess: () => {
-                    toast.success(`${product.title} ditambahkan`);
+                    toast.success(`${product.title}${unit ? ` (${unit.code})` : ""} ditambahkan`);
                     setAddingProductId(null);
                 },
                 onError: () => {

--- a/resources/js/Utils/Menu.jsx
+++ b/resources/js/Utils/Menu.jsx
@@ -29,6 +29,7 @@ import {
     IconUsersPlus,
     IconFileInvoice,
     IconBuildingWarehouse,
+IconRulerMeasure,
     IconCurrencyDollar,
     IconWallet,
     IconFileSearch,
@@ -415,6 +416,13 @@ export default function Menu() {
                     active: url === "/dashboard/settings/warehouses",
                     icon: <IconBuildingWarehouse size={20} strokeWidth={1.5} />,
                     permissions: hasAnyPermission(["warehouses-access"]),
+                },
+                {
+                    title: t("sidebar.items.units"),
+                    href: route("settings.units.index"),
+                    active: url === "/dashboard/settings/units",
+                    icon: <IconRulerMeasure size={20} strokeWidth={1.5} />,
+                    permissions: hasAnyPermission(["units-access"]),
                 },
                 {
                     title: t("sidebar.items.whatsApp"),

--- a/resources/js/i18n/locales/en.json
+++ b/resources/js/i18n/locales/en.json
@@ -202,6 +202,7 @@
             "salesTarget": "Sales Target",
             "priceLists": "Price Lists",
             "warehouses": "Warehouses / Branches",
+            "units": "Units",
             "whatsApp": "WhatsApp"
         },
         "menu": {

--- a/resources/js/i18n/locales/id.json
+++ b/resources/js/i18n/locales/id.json
@@ -202,6 +202,7 @@
             "salesTarget": "Target Penjualan",
             "priceLists": "Price List",
             "warehouses": "Gudang / Cabang",
+            "units": "Satuan",
             "whatsApp": "WhatsApp"
         },
         "menu": {

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\Apps\StockTransferController;
 use App\Http\Controllers\Apps\SupplierController;
 use App\Http\Controllers\Apps\SupplierReturnController;
 use App\Http\Controllers\Apps\TransactionController;
+use App\Http\Controllers\Apps\UnitController;
 use App\Http\Controllers\Apps\WarehouseController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DineMenuController;
@@ -347,6 +348,15 @@ Route::group(['prefix' => 'dashboard', 'middleware' => ['auth', 'verified']], fu
         ->middlewareFor('store', 'permission:warehouses-create')
         ->middlewareFor('update', 'permission:warehouses-update')
         ->middlewareFor('destroy', 'permission:warehouses-delete');
+
+    // settings units
+    Route::resource('/settings/units', UnitController::class)
+        ->except('show')
+        ->names('settings.units')
+        ->middlewareFor('index', 'permission:units-access')
+        ->middlewareFor('store', 'permission:units-create')
+        ->middlewareFor('update', 'permission:units-update')
+        ->middlewareFor('destroy', 'permission:units-delete');
 
     // confirm payment for bank transfer
     Route::patch('/transactions/{transaction}/confirm-payment', [TransactionController::class, 'confirmPayment'])->middleware(['permission:transactions-confirm-payment', 'step_up'])->name('transactions.confirm-payment');

--- a/tests/Feature/Products/ProductUnitTest.php
+++ b/tests/Feature/Products/ProductUnitTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Unit;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ProductUnitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected User $cashier;
+
+    protected Warehouse $pusat;
+
+    protected Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+
+        $this->pusat = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Satuan Uji',
+            'description' => 'Kategori pengujian',
+            'image' => 'category.png',
+        ]);
+    }
+
+    protected function createProduct(array $overrides = []): Product
+    {
+        $product = Product::create(array_merge([
+            'category_id' => $this->category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi uji.',
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'tax_rate' => 0,
+        ], $overrides));
+
+        $this->pusat->products()->attach($product->id, ['stock' => $product->stock]);
+
+        return $product;
+    }
+
+    protected function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'image' => UploadedFile::fake()->image('product.png'),
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi uji.',
+            'category_id' => $this->category->id,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'tax_rate' => 0,
+        ], $overrides);
+    }
+
+    public function test_unit_crud_store_update_destroy(): void
+    {
+        $this->actingAs($this->admin)
+            ->post(route('settings.units.store'), ['code' => 'LSN', 'name' => 'Lusin', 'symbol' => 'lsn'])
+            ->assertRedirect();
+
+        $unit = Unit::where('code', 'LSN')->firstOrFail();
+
+        $this->actingAs($this->admin)
+            ->put(route('settings.units.update', $unit), ['code' => 'LSN', 'name' => 'Lusin Besar', 'symbol' => 'LSN'])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('units', ['id' => $unit->id, 'name' => 'Lusin Besar']);
+
+        $this->actingAs($this->admin)
+            ->delete(route('settings.units.destroy', $unit))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('units', ['id' => $unit->id]);
+    }
+
+    public function test_unit_cannot_be_deleted_while_in_use(): void
+    {
+        $unit = Unit::where('code', 'PCS')->firstOrFail();
+        $product = $this->createProduct();
+        $product->units()->attach($unit->id, [
+            'is_base' => true,
+            'conversion_factor' => 1,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->from(route('settings.units.index'))
+            ->delete(route('settings.units.destroy', $unit))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertDatabaseHas('units', ['id' => $unit->id]);
+    }
+
+    public function test_store_product_with_units_pivot(): void
+    {
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+
+        $this->actingAs($this->admin)
+            ->post(route('products.store'), $this->validPayload([
+                'units' => [
+                    ['unit_id' => $pcs->id, 'is_base' => true, 'conversion_factor' => 1, 'buy_price' => 5000, 'sell_price' => 10000],
+                    ['unit_id' => $box->id, 'is_base' => false, 'conversion_factor' => 12, 'buy_price' => 55000, 'sell_price' => 115000, 'barcode' => 'BRCD-BOX'],
+                ],
+            ]))
+            ->assertRedirect(route('products.index'));
+
+        $product = Product::latest('id')->first();
+
+        $this->assertDatabaseHas('product_units', [
+            'product_id' => $product->id,
+            'unit_id' => $pcs->id,
+            'is_base' => true,
+        ]);
+        $this->assertDatabaseHas('product_units', [
+            'product_id' => $product->id,
+            'unit_id' => $box->id,
+            'conversion_factor' => 12,
+            'sell_price' => 115000,
+            'barcode' => 'BRCD-BOX',
+        ]);
+    }
+
+    public function test_store_without_units_creates_default_base_unit(): void
+    {
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+
+        $this->actingAs($this->admin)
+            ->post(route('products.store'), $this->validPayload())
+            ->assertRedirect(route('products.index'));
+
+        $product = Product::latest('id')->first();
+
+        $this->assertDatabaseHas('product_units', [
+            'product_id' => $product->id,
+            'unit_id' => $pcs->id,
+            'is_base' => true,
+            'conversion_factor' => 1,
+        ]);
+    }
+
+    public function test_web_pos_add_to_cart_with_unit_converts_to_base(): void
+    {
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+
+        $product = $this->createProduct(['stock' => 24]);
+        $product->units()->sync([
+            $pcs->id => ['is_base' => true, 'conversion_factor' => 1, 'buy_price' => 5000, 'sell_price' => 10000],
+            $box->id => ['is_base' => false, 'conversion_factor' => 12, 'buy_price' => 55000, 'sell_price' => 115000],
+        ]);
+
+        $this->seed([PermissionSeeder::class]);
+        $this->actingAs($this->cashier);
+
+        app(CashierShiftService::class)->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+
+        $this->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'sell_price' => 115000,
+            'qty' => 1,
+            'unit_id' => $box->id,
+        ])->assertRedirect();
+
+        $cart = Cart::where('product_id', $product->id)->firstOrFail();
+        // cart stores display qty + conversion factor; base qty = qty * factor
+        $this->assertSame(1, (int) $cart->qty);
+        $this->assertSame(12, (int) round($cart->qty * $cart->conversion_factor));
+        $this->assertSame(115000, (int) $cart->price);
+
+        // stock check: 2 box = 24 base units
+        $this->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'sell_price' => 115000,
+            'qty' => 1,
+            'unit_id' => $box->id,
+        ])->assertRedirect();
+
+        $cart = Cart::where('product_id', $product->id)->firstOrFail();
+        $this->assertSame(2, (int) $cart->qty);
+        $this->assertSame(24, (int) round($cart->qty * $cart->conversion_factor));
+    }
+
+    public function test_web_pos_add_to_cart_exceeding_base_stock_fails(): void
+    {
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+
+        $product = $this->createProduct(['stock' => 10]);
+        $product->units()->sync([
+            $pcs->id => ['is_base' => true, 'conversion_factor' => 1, 'buy_price' => 5000, 'sell_price' => 10000],
+            $box->id => ['is_base' => false, 'conversion_factor' => 12, 'buy_price' => 55000, 'sell_price' => 115000],
+        ]);
+
+        $this->actingAs($this->cashier);
+
+        app(CashierShiftService::class)->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+
+        $this->from(route('transactions.index'))
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'sell_price' => 115000,
+                'qty' => 1,
+                'unit_id' => $box->id,
+            ])
+            ->assertSessionHas('error');
+
+        $this->assertDatabaseMissing('carts', ['product_id' => $product->id]);
+    }
+}


### PR DESCRIPTION
## Summary
Completes multi-unit support (Fase 3 of feature-completeness plan). Stacked on #18 (price-list pricing) ← #17 (composite products).

- Unit master CRUD at `/dashboard/settings/units` (`units-access/create/update/delete` permissions, sidebar entry, i18n id/en); units in use cannot be deleted
- Product form: per-product units (base + additional with conversion_factor, sell_price, barcode); products without units get default PCS base unit; hidden for composite products
- Web POS: unit chip selector on product cards, add-to-cart posts unit_id, price per unit, stock checked in base units
- API/mobile POS path already supported units — behavior now matches web POS

## Test plan
- New `ProductUnitTest` (6 tests): unit CRUD, delete-in-use rejection, units pivot sync, default base unit, web POS add-to-cart conversion (1 BOX = 12 PCS) + stock guard
- Full suite: 173 passed (802 assertions), pint clean, vite build passes