### PR TITLE
feat(reorder): reorder point fields and daily draft PO generation

### DIFF
--- a/app/Console/Commands/GenerateReorderCommand.php
+++ b/app/Console/Commands/GenerateReorderCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\ReorderService;
+use Illuminate\Console\Command;
+
+class GenerateReorderCommand extends Command
+{
+    protected $signature = 'reorder:generate';
+
+    protected $description = 'Create draft purchase orders from low-stock reorder points';
+
+    public function handle(ReorderService $reorderService): int
+    {
+        $products = $reorderService->getLowStockProducts();
+
+        if ($products->isEmpty()) {
+            $this->info('No low-stock products.');
+
+            return self::SUCCESS;
+        }
+
+        // ponytail: first admin is the PO author; add per-warehouse assignment if needed
+        $userId = User::role('super-admin')->orderBy('id')->value('id')
+            ?? User::orderBy('id')->value('id');
+
+        $order = $reorderService->createDraftPurchaseOrder($products, $userId);
+
+        if (! $order) {
+            $this->info('Low-stock products found, but no reorder quantity to suggest.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Draft purchase order #{$order->id} created with {$order->items->count()} item(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/resources/js/Pages/Dashboard/Products/Create.jsx
+++ b/resources/js/Pages/Dashboard/Products/Create.jsx
@@ -31,6 +31,8 @@ export default function Create({ categories, products, units = [] }) {
         buy_price: "",
         sell_price: "",
         stock: "",
+        min_stock: "",
+        max_stock: "",
         is_composite: false,
         components: [],
         units: [],
@@ -340,6 +342,35 @@ export default function Create({ categories, products, units = [] }) {
                                             : "0"
                                     }
                                 />
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                                <Input
+                                    type="number"
+                                    label="Stok Minimum"
+                                    value={data.min_stock}
+                                    onChange={(e) =>
+                                        setData("min_stock", e.target.value)
+                                    }
+                                    errors={errors.min_stock}
+                                    placeholder="0"
+                                />
+                                <Input
+                                    type="number"
+                                    label="Stok Maksimum"
+                                    value={data.max_stock}
+                                    onChange={(e) =>
+                                        setData("max_stock", e.target.value)
+                                    }
+                                    errors={errors.max_stock}
+                                    placeholder="0"
+                                />
+                                <p className="sm:col-span-2 text-xs text-slate-500 dark:text-slate-400">
+                                    Dipakai untuk reorder point: saat stok
+                                    menyentuh minimum, draft purchase order
+                                    otomatis dibuat oleh sistem (reorder:generate
+                                    harian).
+                                </p>
                             </div>
 
                             {/* Profit Estimation */}

--- a/resources/js/Pages/Dashboard/Products/Edit.jsx
+++ b/resources/js/Pages/Dashboard/Products/Edit.jsx
@@ -30,6 +30,8 @@ export default function Edit({ categories, product, products = [], units = [] })
         description: product.description,
         buy_price: product.buy_price,
         sell_price: product.sell_price,
+        min_stock: product.min_stock ?? "",
+        max_stock: product.max_stock ?? "",
         is_composite: product.is_composite ?? false,
         components: (product.components ?? []).map((c) => ({
             component_product_id: c.id,
@@ -515,7 +517,37 @@ export default function Edit({ categories, product, products = [], units = [] })
                                         : product.stock}
                                 </p>
                                 <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                                    Perubahan stok dilakukan melalui transaksi atau stock opname.
+                                    Perubahan stok dilakukan melalui transaksi
+                                    atau stock opname.
+                                </p>
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                                <Input
+                                    type="number"
+                                    label="Stok Minimum"
+                                    value={data.min_stock}
+                                    onChange={(e) =>
+                                        setData("min_stock", e.target.value)
+                                    }
+                                    errors={errors.min_stock}
+                                    placeholder="0"
+                                />
+                                <Input
+                                    type="number"
+                                    label="Stok Maksimum"
+                                    value={data.max_stock}
+                                    onChange={(e) =>
+                                        setData("max_stock", e.target.value)
+                                    }
+                                    errors={errors.max_stock}
+                                    placeholder="0"
+                                />
+                                <p className="sm:col-span-2 text-xs text-slate-500 dark:text-slate-400">
+                                    Dipakai untuk reorder point: saat stok
+                                    menyentuh minimum, draft purchase order
+                                    otomatis dibuat oleh sistem (reorder:generate
+                                    harian).
                                 </p>
                             </div>
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,3 +10,4 @@ Artisan::command('inspire', function () {
 
 Schedule::command('crm:sync-segments')->dailyAt('01:00');
 Schedule::command('crm:generate-reminders')->dailyAt('01:15');
+Schedule::command('reorder:generate')->dailyAt('02:00');

--- a/tests/Feature/Products/ReorderPointTest.php
+++ b/tests/Feature/Products/ReorderPointTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\PurchaseOrder;
+use App\Models\User;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReorderPointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->actingAs(User::where('email', 'arya@gmail.com')->first());
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(array $overrides = []): Product
+    {
+        self::$seq++;
+
+        $product = Product::create(array_merge([
+            'title' => 'Produk '.self::$seq,
+            'sku' => 'SKU-'.self::$seq,
+            'buy_price' => 10000,
+            'sell_price' => 15000,
+            'stock' => 100,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-'.self::$seq,
+            'description' => 'Deskripsi produk test',
+            'tax_rate' => 0,
+            'category_id' => $this->category->id,
+        ], $overrides));
+
+        // suggestedOrderQty() reads stock from the product_warehouse pivot
+        $product->warehouses()->attach($this->warehouse->id, ['stock' => $product->stock]);
+
+        return $product;
+    }
+
+    public function test_generate_creates_draft_po_with_suggested_qty(): void
+    {
+        $this->createProduct(['min_stock' => 50, 'max_stock' => 200, 'stock' => 40]);
+
+        $this->artisan('reorder:generate')->assertSuccessful();
+
+        $order = PurchaseOrder::latest('id')->first();
+        $this->assertNotNull($order);
+        $this->assertEquals('draft', $order->status);
+        $item = $order->items->first();
+        $this->assertEquals(160, $item->qty_ordered); // max 200 - stock 40
+        $this->assertEquals(10000, $item->unit_price);
+    }
+
+    public function test_generate_skips_low_stock_without_max(): void
+    {
+        $this->createProduct(['min_stock' => 50, 'stock' => 10]);
+
+        $this->artisan('reorder:generate')
+            ->expectsOutput('Low-stock products found, but no reorder quantity to suggest.')
+            ->assertSuccessful();
+
+        $this->assertNull(PurchaseOrder::latest('id')->first());
+    }
+
+    public function test_generate_does_nothing_when_healthy(): void
+    {
+        $this->createProduct(['min_stock' => 10, 'max_stock' => 200, 'stock' => 100]);
+
+        $this->artisan('reorder:generate')
+            ->expectsOutput('No low-stock products.')
+            ->assertSuccessful();
+
+        $this->assertNull(PurchaseOrder::latest('id')->first());
+    }
+}


### PR DESCRIPTION
Stacked on #19 (feature/product-units). Part of completing orphaned backend features.

- Min/Max stock inputs on Products Create/Edit forms (backend validation already existed)
- New `reorder:generate` artisan command: creates draft PO for low-stock products (ReorderService, previously unused)
- Scheduled daily at 02:00 in routes/console.php
- ReorderPointTest (3 tests)

Full suite: 176 passed (813 assertions).