### PR TITLE
feat(products): per-product tax type and rate fields

### DIFF
--- a/app/Http/Controllers/Apps/ProductController.php
+++ b/app/Http/Controllers/Apps/ProductController.php
@@ -84,6 +84,8 @@ class ProductController extends Controller
             'stock' => 'required|integer|min:0',
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
+            'tax_type' => 'nullable|in:exclusive,inclusive',
+            'tax_rate' => 'nullable|numeric|min:0|max:100',
             ...$this->compositeRules(),
             ...$this->unitRules(),
         ]);
@@ -104,6 +106,8 @@ class ProductController extends Controller
             'stock' => $request->stock,
             'min_stock' => $request->min_stock ?? 0,
             'max_stock' => $request->max_stock ?? 0,
+            'tax_type' => $request->input('tax_type', 'exclusive'),
+            'tax_rate' => $request->input('tax_rate', 11.00),
             'is_composite' => $request->boolean('is_composite'),
         ]);
 
@@ -174,6 +178,8 @@ class ProductController extends Controller
             'sell_price' => 'required',
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
+            'tax_type' => 'nullable|in:exclusive,inclusive',
+            'tax_rate' => 'nullable|numeric|min:0|max:100',
             ...$this->compositeRules(),
             ...$this->unitRules(),
         ]);
@@ -206,6 +212,8 @@ class ProductController extends Controller
                 'category_id' => $request->category_id,
                 'buy_price' => $request->buy_price,
                 'sell_price' => $request->sell_price,
+                'tax_type' => $request->input('tax_type', 'exclusive'),
+                'tax_rate' => $request->input('tax_rate', 11.00),
                 'is_composite' => $request->boolean('is_composite'),
             ]);
 
@@ -229,6 +237,8 @@ class ProductController extends Controller
             'category_id' => $request->category_id,
             'buy_price' => $request->buy_price,
             'sell_price' => $request->sell_price,
+            'tax_type' => $request->input('tax_type', 'exclusive'),
+            'tax_rate' => $request->input('tax_rate', 11.00),
             'is_composite' => $request->boolean('is_composite'),
         ]);
 

--- a/resources/js/Pages/Dashboard/Products/Create.jsx
+++ b/resources/js/Pages/Dashboard/Products/Create.jsx
@@ -33,6 +33,8 @@ export default function Create({ categories, products, units = [] }) {
         stock: "",
         min_stock: "",
         max_stock: "",
+        tax_type: "exclusive",
+        tax_rate: "11",
         is_composite: false,
         components: [],
         units: [],
@@ -371,6 +373,67 @@ export default function Create({ categories, products, units = [] }) {
                                     otomatis dibuat oleh sistem (reorder:generate
                                     harian).
                                 </p>
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                        Tipe Pajak
+                                    </label>
+                                    <div className="flex gap-4">
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="tax_type"
+                                                value="exclusive"
+                                                checked={
+                                                    data.tax_type ===
+                                                    "exclusive"
+                                                }
+                                                onChange={(e) =>
+                                                    setData(
+                                                        "tax_type",
+                                                        e.target.value
+                                                    )
+                                                }
+                                            />
+                                            Exclusive
+                                        </label>
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="tax_type"
+                                                value="inclusive"
+                                                checked={
+                                                    data.tax_type ===
+                                                    "inclusive"
+                                                }
+                                                onChange={(e) =>
+                                                    setData(
+                                                        "tax_type",
+                                                        e.target.value
+                                                    )
+                                                }
+                                            />
+                                            Inclusive
+                                        </label>
+                                    </div>
+                                    {errors.tax_type && (
+                                        <p className="text-xs text-danger-500 mt-1">
+                                            {errors.tax_type}
+                                        </p>
+                                    )}
+                                </div>
+                                <Input
+                                    type="number"
+                                    label="Persentase Pajak (%)"
+                                    value={data.tax_rate}
+                                    onChange={(e) =>
+                                        setData("tax_rate", e.target.value)
+                                    }
+                                    errors={errors.tax_rate}
+                                    placeholder="11"
+                                />
                             </div>
 
                             {/* Profit Estimation */}

--- a/resources/js/Pages/Dashboard/Products/Edit.jsx
+++ b/resources/js/Pages/Dashboard/Products/Edit.jsx
@@ -32,6 +32,8 @@ export default function Edit({ categories, product, products = [], units = [] })
         sell_price: product.sell_price,
         min_stock: product.min_stock ?? "",
         max_stock: product.max_stock ?? "",
+        tax_type: product.tax_type ?? "exclusive",
+        tax_rate: product.tax_rate ?? "11",
         is_composite: product.is_composite ?? false,
         components: (product.components ?? []).map((c) => ({
             component_product_id: c.id,
@@ -549,6 +551,67 @@ export default function Edit({ categories, product, products = [], units = [] })
                                     otomatis dibuat oleh sistem (reorder:generate
                                     harian).
                                 </p>
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                        Tipe Pajak
+                                    </label>
+                                    <div className="flex gap-4">
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="tax_type"
+                                                value="exclusive"
+                                                checked={
+                                                    data.tax_type ===
+                                                    "exclusive"
+                                                }
+                                                onChange={(e) =>
+                                                    setData(
+                                                        "tax_type",
+                                                        e.target.value
+                                                    )
+                                                }
+                                            />
+                                            Exclusive
+                                        </label>
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="tax_type"
+                                                value="inclusive"
+                                                checked={
+                                                    data.tax_type ===
+                                                    "inclusive"
+                                                }
+                                                onChange={(e) =>
+                                                    setData(
+                                                        "tax_type",
+                                                        e.target.value
+                                                    )
+                                                }
+                                            />
+                                            Inclusive
+                                        </label>
+                                    </div>
+                                    {errors.tax_type && (
+                                        <p className="text-xs text-danger-500 mt-1">
+                                            {errors.tax_type}
+                                        </p>
+                                    )}
+                                </div>
+                                <Input
+                                    type="number"
+                                    label="Persentase Pajak (%)"
+                                    value={data.tax_rate}
+                                    onChange={(e) =>
+                                        setData("tax_rate", e.target.value)
+                                    }
+                                    errors={errors.tax_rate}
+                                    placeholder="11"
+                                />
                             </div>
 
                             {/* Profit Estimation */}

--- a/tests/Feature/Products/ProductTaxTest.php
+++ b/tests/Feature/Products/ProductTaxTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class ProductTaxTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([
+            PermissionSeeder::class,
+            RoleSeeder::class,
+            UserSeeder::class,
+        ]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'image' => UploadedFile::fake()->image('product.jpg'),
+            'barcode' => 'BC-'.uniqid(),
+            'sku' => 'SKU-'.uniqid(),
+            'title' => 'Produk Pajak',
+            'description' => 'Deskripsi',
+            'category_id' => Category::create([
+                'name' => 'Kat '.uniqid(),
+                'image' => 'categories/test.jpg',
+                'description' => 'Deskripsi kategori',
+            ])->id,
+            'buy_price' => 10000,
+            'sell_price' => 15000,
+            'stock' => 10,
+            'tax_type' => 'inclusive',
+            'tax_rate' => '5.5',
+        ], $overrides);
+    }
+
+    public function test_store_persists_tax_type_and_rate(): void
+    {
+        $response = $this->post(route('products.store'), $this->validPayload());
+
+        $response->assertRedirect(route('products.index'));
+
+        $product = Product::latest('id')->first();
+        $this->assertEquals('inclusive', $product->tax_type);
+        $this->assertEquals(5.5, $product->tax_rate);
+    }
+
+    public function test_store_defaults_tax_when_not_sent(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['tax_type'], $payload['tax_rate']);
+
+        $this->post(route('products.store'), $payload);
+
+        $product = Product::latest('id')->first();
+        $this->assertEquals('exclusive', $product->tax_type);
+        $this->assertEquals(11.00, $product->tax_rate);
+    }
+
+    public function test_update_persists_tax_type_and_rate(): void
+    {
+        $product = Product::create([
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-1',
+            'sku' => 'SKU-1',
+            'title' => 'Produk Lama',
+            'description' => 'Deskripsi',
+            'category_id' => Category::create([
+                'name' => 'Kat '.uniqid(),
+                'image' => 'categories/test.jpg',
+                'description' => 'Deskripsi kategori',
+            ])->id,
+            'buy_price' => 10000,
+            'sell_price' => 15000,
+            'stock' => 10,
+            'tax_rate' => 0,
+        ]);
+
+        $payload = $this->validPayload([
+            'tax_type' => 'exclusive',
+            'tax_rate' => '0',
+            '_method' => 'PUT',
+        ]);
+
+        $this->post(route('products.update', $product->id), $payload);
+
+        $product->refresh();
+        $this->assertEquals('exclusive', $product->tax_type);
+        $this->assertEquals(0, $product->tax_rate);
+    }
+
+    public function test_store_rejects_invalid_tax_rate(): void
+    {
+        $this->post(route('products.store'), $this->validPayload([
+            'tax_rate' => '150',
+        ]))->assertSessionHasErrors('tax_rate');
+    }
+}


### PR DESCRIPTION
Stacked on #20 (feature/reorder-point). Products table already had tax_type/tax_rate columns and checkout already reads them (LoyaltyService via TaxService) — this adds the missing product form UI + persistence.

- ProductController: tax_type/tax_rate validation + save (store + both update branches, defaults exclusive/11.00)
- Products Create/Edit: Tipe Pajak radio (exclusive/inclusive) + Persentase Pajak input
- ProductTaxTest (4 tests): persist, defaults, update, validation reject

Full suite: 180 passed (823 assertions).