### PR TITLE
feat(batch): FEFO batch allocation at checkout and expiring batch notifications

### DIFF
--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -12,11 +12,13 @@ use App\Models\CustomerVoucher;
 use App\Models\DiscountApprovalLog;
 use App\Models\PaymentSetting;
 use App\Models\Product;
+use App\Models\ProductBatch;
 use App\Models\ProductWarehouse;
 use App\Models\Receivable;
 use App\Models\Transaction;
 use App\Models\Warehouse;
 use App\Services\AuditLogService;
+use App\Services\BatchService;
 use App\Services\CashierShiftService;
 use App\Services\LoyaltyService;
 use App\Services\Payments\PaymentGatewayManager;
@@ -38,7 +40,8 @@ class TransactionController extends Controller
         private readonly AuditLogService $auditLogService,
         private readonly PricingService $pricingService,
         private readonly LoyaltyService $loyaltyService,
-        private readonly PriceListService $priceListService
+        private readonly PriceListService $priceListService,
+        private readonly BatchService $batchService
     ) {}
 
     /**
@@ -706,6 +709,19 @@ class TransactionController extends Controller
                         'warehouse_id' => $activeShift->warehouse_id,
                     ])->decrement('stock', $baseQty);
                     $product->decrement('stock', $baseQty);
+
+                    // FEFO: consume batch stock when the product has batches, else legacy path unchanged
+                    if (ProductBatch::where('product_id', $product->id)
+                        ->where('warehouse_id', $activeShift->warehouse_id)
+                        ->where('stock', '>', 0)->exists()) {
+                        $allocations = $this->batchService->allocate($product, $activeShift->warehouse_id, $baseQty);
+                        foreach ($allocations as $allocation) {
+                            ProductBatch::where('id', $allocation['batch_id'])->decrement('stock', $allocation['qty']);
+                        }
+                        if ($allocations !== []) {
+                            $detail->update(['product_batch_id' => $allocations[0]['batch_id']]);
+                        }
+                    }
                 }
             }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -6,6 +6,7 @@ use App\Models\CashierShift;
 use App\Models\DineOrder;
 use App\Models\Payable;
 use App\Models\Product;
+use App\Models\ProductBatch;
 use App\Models\Receivable;
 use App\Models\Setting;
 use App\Models\Transaction;
@@ -29,6 +30,7 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request): array
     {
         $lowStockNotifications = [];
+        $expiringBatchNotifications = [];
         $receivableNotifications = [];
         $payableNotifications = [];
         $activeCashierShift = null;
@@ -68,6 +70,23 @@ class HandleInertiaRequests extends Middleware
                         'title' => $product->title,
                         'stock' => (int) $product->stock,
                         'time' => optional($product->updated_at)->diffForHumans(),
+                    ];
+                });
+
+            $expiringBatchNotifications = ProductBatch::with('product:id,title')
+                ->where('stock', '>', 0)
+                ->whereNotNull('expired_at')
+                ->whereBetween('expired_at', [now(), now()->addDays(30)])
+                ->orderBy('expired_at')
+                ->limit(10)
+                ->get()
+                ->map(function ($batch) {
+                    return [
+                        'id' => $batch->id,
+                        'title' => $batch->product?->title,
+                        'batch_number' => $batch->batch_number,
+                        'stock' => (int) $batch->stock,
+                        'time' => optional($batch->expired_at)->diffForHumans(),
                     ];
                 });
 
@@ -179,6 +198,7 @@ class HandleInertiaRequests extends Middleware
                 ],
             ],
             'lowStockNotifications' => $lowStockNotifications,
+            'expiringBatchNotifications' => $expiringBatchNotifications,
             'receivableNotifications' => $receivableNotifications,
             'payableNotifications' => $payableNotifications,
             'payableAgingSummary' => $payableAgingSummary,

--- a/app/Models/TransactionDetail.php
+++ b/app/Models/TransactionDetail.php
@@ -24,6 +24,7 @@ class TransactionDetail extends Model
         'unit_price',
         'price',
         'discount_total',
+        'product_batch_id',
         'pricing_rule_id',
         'pricing_rule_name',
         'pricing_rule_kind',

--- a/resources/js/Components/Dashboard/Notification.jsx
+++ b/resources/js/Components/Dashboard/Notification.jsx
@@ -13,6 +13,7 @@ import { usePage, router } from "@inertiajs/react";
 export default function Notification() {
     const {
         lowStockNotifications = [],
+        expiringBatchNotifications = [],
         receivableNotifications = [],
         payableNotifications = [],
     } = usePage().props;
@@ -46,6 +47,16 @@ export default function Notification() {
                 title: `Stok habis: ${n.title}`,
                 subtitle: `Stok: ${n.stock}`,
                 type: "stock",
+            }))
+        ),
+        ...mapItems(
+            expiringBatchNotifications.map((n) => ({
+                ...n,
+                id: `batch-${n.id}`,
+                title: `Batch kedaluwarsa: ${n.title}`,
+                subtitle: `${n.batch_number} • Stok: ${n.stock}`,
+                type: "stock",
+                noAck: true,
             }))
         ),
         ...mapItems(
@@ -94,11 +105,14 @@ export default function Notification() {
     // Sync when low stock changes (e.g., restocked items disappear)
     useEffect(() => {
         setData(mergeData());
-    }, [lowStockNotifications, receivableNotifications, payableNotifications]);
+    },         [lowStockNotifications, expiringBatchNotifications, receivableNotifications, payableNotifications]);
 
     const handleMarkRead = (id) => {
-        setData((prev) => prev.filter((item) => item.id !== id));
         const item = data.find((d) => d.id === id);
+        if (item?.noAck) {
+            return;
+        }
+        setData((prev) => prev.filter((item) => item.id !== id));
         if (item?.type === "stock") {
             router.post(
                 route("notifications.stock.read"),
@@ -144,7 +158,8 @@ export default function Notification() {
                     </div>
                     <button
                         onClick={() => handleMarkRead(item.id)}
-                        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold text-primary-600 hover:bg-primary-50 dark:text-primary-300 dark:hover:bg-primary-900/30 border border-transparent hover:border-primary-200 dark:hover:border-primary-800"
+                        disabled={item.noAck}
+                        className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold text-primary-600 hover:bg-primary-50 dark:text-primary-300 dark:hover:bg-primary-900/30 border border-transparent hover:border-primary-200 dark:hover:border-primary-800 ${item.noAck ? "opacity-50 cursor-default" : ""}`}
                     >
                         <IconCircleCheck size={16} />
                         Dibaca

--- a/tests/Feature/Products/BatchFefoTest.php
+++ b/tests/Feature/Products/BatchFefoTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductBatch;
+use App\Models\ProductWarehouse;
+use App\Models\TransactionDetail;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BatchFefoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $cashier;
+
+    private Warehouse $pusat;
+
+    private Category $category;
+
+    private CashierShiftService $cashierShiftService;
+
+    private static int $seq = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([
+            PermissionSeeder::class,
+            RoleSeeder::class,
+            UserSeeder::class,
+        ]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+
+        $this->cashierShiftService = app(CashierShiftService::class);
+
+        $this->pusat = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Test Category',
+            'image' => 'test.png',
+            'description' => 'desc',
+        ]);
+    }
+
+    private function createProduct(int $stock = 0): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Batched Product '.self::$seq,
+            'sku' => 'SKU-BATCH-'.self::$seq,
+            'barcode' => 'BC-BATCH-'.self::$seq,
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 1000,
+            'sell_price' => 2000,
+            'stock' => $stock,
+            'tax_rate' => 0,
+        ]);
+
+        $product->warehouses()->attach($this->pusat->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function createBatch(Product $product, string $batchNumber, string $expiredAt, int $stock): ProductBatch
+    {
+        return ProductBatch::create([
+            'product_id' => $product->id,
+            'warehouse_id' => $this->pusat->id,
+            'batch_number' => $batchNumber,
+            'expired_at' => $expiredAt,
+            'received_at' => '2026-01-01',
+            'stock' => $stock,
+        ]);
+    }
+
+    private function startShift(): void
+    {
+        $this->cashierShiftService->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+    }
+
+    private function addToCart(Product $product, int $qty = 1): void
+    {
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'sell_price' => $product->sell_price,
+                'qty' => $qty,
+            ])
+            ->assertRedirect();
+    }
+
+    public function test_checkout_decrements_fefo_batch_first(): void
+    {
+        $product = $this->createProduct(30);
+        $batchA = $this->createBatch($product, 'BATCH-A', now()->addDays(10)->toDateString(), 5);
+        $batchB = $this->createBatch($product, 'BATCH-B', now()->addDays(60)->toDateString(), 20);
+
+        $this->startShift();
+        $this->addToCart($product, 8);
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 100000])
+            ->assertRedirect();
+
+        $this->assertEquals(0, $batchA->fresh()->stock);
+        $this->assertEquals(17, $batchB->fresh()->stock);
+        $this->assertEquals(22, $product->fresh()->stock);
+        $this->assertEquals(22, ProductWarehouse::where('product_id', $product->id)
+            ->where('warehouse_id', $this->pusat->id)->value('stock'));
+
+        $detail = TransactionDetail::latest('id')->first();
+        $this->assertEquals($batchA->id, $detail->product_batch_id);
+    }
+
+    public function test_checkout_without_batches_keeps_detail_batch_null(): void
+    {
+        $product = $this->createProduct(10);
+
+        $this->startShift();
+        $this->addToCart($product, 2);
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertRedirect();
+
+        $detail = TransactionDetail::latest('id')->first();
+        $this->assertNull($detail->product_batch_id);
+        $this->assertEquals(8, $product->fresh()->stock);
+    }
+
+    public function test_expiring_soon_scope_returns_batches_within_30_days(): void
+    {
+        $product = $this->createProduct(10);
+        $soon = $this->createBatch($product, 'SOON', now()->addDays(10)->toDateString(), 5);
+        $this->createBatch($product, 'LATER', now()->addDays(90)->toDateString(), 5);
+
+        $ids = ProductBatch::expiringSoon(30)->pluck('id');
+
+        $this->assertContains($soon->id, $ids);
+        $this->assertCount(1, $ids);
+    }
+
+    public function test_expired_scope_excludes_non_expired(): void
+    {
+        $product = $this->createProduct(10);
+        $expired = $this->createBatch($product, 'OLD', now()->subDays(5)->toDateString(), 5);
+        $this->createBatch($product, 'OK', now()->addDays(90)->toDateString(), 5);
+
+        $ids = ProductBatch::expired()->pluck('id');
+
+        $this->assertContains($expired->id, $ids);
+        $this->assertCount(1, $ids);
+    }
+}


### PR DESCRIPTION
Stacked on #21 (feature/product-tax-ui).

## Summary
- Wire BatchService::allocate into web POS checkout: when a product has batches in the active warehouse, stock is consumed FEFO (earliest expiry first) and transaction_details.product_batch_id records the primary batch. Products without batches keep the legacy decrement path.
- Expiring batch notifications (≤30 days, stock > 0) surfaced via shared Inertia props into the existing dashboard notification bell. Items are view-only (no mark-read) — they self-clear when expired or stock hits zero.
- transaction_details.product_batch_id added to TransactionDetail fillable.
- Tests: BatchFefoTest (4 tests) — FEFO decrement order across two batches + product_batch_id recorded, legacy path unchanged for non-batched products, expiringSoon/expired scopes.

Suite: 184 passed (838 assertions).