### PR TITLE
fix(inventory): stock integrity on receiving, product create, opname, links

### DIFF
--- a/app/Http/Controllers/Apps/GoodsReceivingController.php
+++ b/app/Http/Controllers/Apps/GoodsReceivingController.php
@@ -68,9 +68,15 @@ class GoodsReceivingController extends Controller
             'items.*.purchase_order_item_id' => ['required', 'exists:purchase_order_items,id'],
             'items.*.qty_received' => ['required', 'integer', 'min:1'],
             'items.*.notes' => ['nullable', 'string', 'max:500'],
+            'items.*.batch_number' => ['nullable', 'string', 'max:255'],
+            'items.*.expired_at' => ['nullable', 'date'],
         ]);
 
         $order = PurchaseOrder::with('items')->findOrFail($data['purchase_order_id']);
+
+        if (! in_array($order->status, ['ordered', 'partial_received'])) {
+            return back()->with('error', 'Hanya PO berstatus ordered/partial yang dapat diterima.');
+        }
 
         foreach ($data['items'] as $item) {
             $poItem = $order->items->firstWhere('id', $item['purchase_order_item_id']);

--- a/app/Http/Controllers/Apps/ProductController.php
+++ b/app/Http/Controllers/Apps/ProductController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Apps;
 use App\Http\Controllers\Controller;
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\ProductWarehouse;
 use App\Models\Unit;
 use App\Models\Warehouse;
 use App\Services\AuditLogService;
@@ -74,6 +75,7 @@ class ProductController extends Controller
          * validate
          */
         $request->validate([
+            'image' => 'required|image|mimes:jpeg,jpg,png,webp|max:2048',
             'barcode' => 'required|unique:products,barcode',
             'sku' => 'required|unique:products,sku',
             'title' => 'required',
@@ -82,6 +84,7 @@ class ProductController extends Controller
             'buy_price' => 'required',
             'sell_price' => 'required',
             'stock' => 'required|integer|min:0',
+            'warehouse_id' => 'nullable|exists:warehouses,id',
             'min_stock' => 'nullable|integer|min:0',
             'max_stock' => 'nullable|integer|min:0',
             'tax_type' => 'nullable|in:exclusive,inclusive',
@@ -116,7 +119,20 @@ class ProductController extends Controller
             $this->syncComponents($product, $request->input('components'));
         } else {
             $this->syncUnits($product, $request->input('units'));
-            $this->stockMutationService->recordInitialStock($product, $request->user()?->id);
+
+            // ponytail: keep global products.stock and per-warehouse pivot in sync; PUSAT (first active main) is the default warehouse
+            $warehouse = Warehouse::find($request->warehouse_id)
+                ?? Warehouse::active()->where('type', 'main')->orderBy('sort_order')->orderBy('code')->first()
+                ?? Warehouse::active()->orderBy('sort_order')->orderBy('code')->first();
+
+            if ($warehouse) {
+                ProductWarehouse::updateOrCreate(
+                    ['product_id' => $product->id, 'warehouse_id' => $warehouse->id],
+                    ['stock' => (int) $request->stock]
+                );
+            }
+
+            $this->stockMutationService->recordInitialStock($product, $request->user()?->id, $warehouse?->id);
         }
         $this->auditLogService->log(
             event: 'product.created',
@@ -212,6 +228,8 @@ class ProductController extends Controller
                 'category_id' => $request->category_id,
                 'buy_price' => $request->buy_price,
                 'sell_price' => $request->sell_price,
+                'min_stock' => $request->min_stock ?? 0,
+                'max_stock' => $request->max_stock ?? 0,
                 'tax_type' => $request->input('tax_type', 'exclusive'),
                 'tax_rate' => $request->input('tax_rate', 11.00),
                 'is_composite' => $request->boolean('is_composite'),
@@ -237,6 +255,8 @@ class ProductController extends Controller
             'category_id' => $request->category_id,
             'buy_price' => $request->buy_price,
             'sell_price' => $request->sell_price,
+            'min_stock' => $request->min_stock ?? 0,
+            'max_stock' => $request->max_stock ?? 0,
             'tax_type' => $request->input('tax_type', 'exclusive'),
             'tax_rate' => $request->input('tax_rate', 11.00),
             'is_composite' => $request->boolean('is_composite'),

--- a/app/Http/Controllers/Apps/StockOpnameController.php
+++ b/app/Http/Controllers/Apps/StockOpnameController.php
@@ -231,19 +231,26 @@ class StockOpnameController extends Controller
                     continue;
                 }
 
-                $stockBefore = (int) $product->stock;
                 $stockAfter = (int) $item->physical_stock;
 
-                $product->update([
-                    'stock' => $stockAfter,
-                ]);
-
-                // Update pivot stock for warehouse
                 if ($stockOpname->warehouse_id) {
-                    ProductWarehouse::where([
+                    // ponytail: opname is per-warehouse — only touch that warehouse's pivot, then recompute the legacy aggregate
+                    $before = ProductWarehouse::where([
                         'product_id' => $product->id,
                         'warehouse_id' => $stockOpname->warehouse_id,
-                    ])->update(['stock' => $stockAfter]);
+                    ])->lockForUpdate()->first();
+
+                    $stockBefore = (int) ($before?->stock ?? 0);
+
+                    ProductWarehouse::updateOrCreate(
+                        ['product_id' => $product->id, 'warehouse_id' => $stockOpname->warehouse_id],
+                        ['stock' => $stockAfter]
+                    );
+
+                    $product->update(['stock' => $product->stockTotal()]);
+                } else {
+                    $stockBefore = (int) $product->stock;
+                    $product->update(['stock' => $stockAfter]);
                 }
 
                 $this->stockMutationService->recordStockOpnameAdjustment(

--- a/app/Services/GoodsReceivingService.php
+++ b/app/Services/GoodsReceivingService.php
@@ -58,21 +58,22 @@ class GoodsReceivingService
                 $poItem->increment('qty_received', $qtyReceived);
 
                 $product = $poItem->product;
-                // Decrement legacy stock
-                $product->decrement('stock', $qtyReceived);
+                $stockBefore = (int) $product->stock;
+                // Increment legacy stock
+                $product->increment('stock', $qtyReceived);
                 // Increment warehouse pivot stock
                 if ($order->warehouse_id) {
-                    ProductWarehouse::where([
-                        'product_id' => $product->id,
-                        'warehouse_id' => $order->warehouse_id,
-                    ])->increment('stock', $qtyReceived);
+                    ProductWarehouse::firstOrCreate(
+                        ['product_id' => $product->id, 'warehouse_id' => $order->warehouse_id],
+                        ['stock' => 0]
+                    )->increment('stock', $qtyReceived);
                 }
 
                 // Create batch record
-                if (! empty($item['batch_number'])) {
+                if (! empty($item['batch_number']) && $order->warehouse_id) {
                     ProductBatch::create([
                         'product_id' => $product->id,
-                        'warehouse_id' => $order->warehouse_id ?? 1,
+                        'warehouse_id' => $order->warehouse_id,
                         'batch_number' => $item['batch_number'],
                         'expired_at' => $item['expired_at'] ?? null,
                         'received_at' => now(),
@@ -84,7 +85,7 @@ class GoodsReceivingService
                     product: $product,
                     goodsReceiving: $receiving,
                     qty: $qtyReceived,
-                    stockBefore: (int) $product->stock + $qtyReceived,
+                    stockBefore: $stockBefore,
                     stockAfter: (int) $product->stock,
                     notes: 'Penerimaan dari PO '.$order->document_number,
                     userId: $userId,

--- a/resources/js/Components/Dashboard/Button.jsx
+++ b/resources/js/Components/Dashboard/Button.jsx
@@ -48,10 +48,23 @@ export default function Button({
 
     return (
         <>
-            {type === "link" && (
+            {type === "link" && href && (
+                <Link
+                    href={href}
+                    className={`${baseStyles} ${sizeStyles} ${className}`}
+                >
+                    {icon}{" "}
+                    <span
+                        className={`${added === true ? "hidden lg:block" : ""}`}
+                    >
+                        {label}
+                    </span>
+                </Link>
+            )}
+            {type === "link" && !href && (
                 <button
                     type="button"
-                    onClick={href ? undefined : props.onClick}
+                    onClick={props.onClick}
                     className={`${baseStyles} ${sizeStyles} ${className}`}
                 >
                     {icon}{" "}
@@ -64,6 +77,7 @@ export default function Button({
             )}
             {type === "button" && (
                 <button
+                    type="button"
                     className={`${baseStyles} ${sizeStyles} ${className}`}
                     {...props}
                 >

--- a/resources/js/Pages/Dashboard/Categories/Edit.jsx
+++ b/resources/js/Pages/Dashboard/Categories/Edit.jsx
@@ -22,9 +22,7 @@ export default function Edit({ category }) {
         _method: "PUT",
     });
 
-    const [imagePreview, setImagePreview] = useState(
-        category.image ? `/storage/categories/${category.image}` : null
-    );
+    const [imagePreview, setImagePreview] = useState(category.image || null);
 
     const handleImageChange = (e) => {
         const file = e.target.files[0];

--- a/tests/Feature/Products/ProductStoreTest.php
+++ b/tests/Feature/Products/ProductStoreTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductWarehouse;
+use App\Models\StockMutation;
+use App\Models\User;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ProductStoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'image' => UploadedFile::fake()->image('product.png'),
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi uji.',
+            'category_id' => $this->category->id,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'tax_rate' => 0,
+        ], $overrides);
+    }
+
+    public function test_store_creates_pivot_row_in_default_warehouse(): void
+    {
+        $this->post(route('products.store'), $this->validPayload())
+            ->assertRedirect(route('products.index'));
+
+        $product = Product::latest('id')->first();
+
+        $pivot = ProductWarehouse::where('product_id', $product->id)
+            ->where('warehouse_id', $this->warehouse->id)
+            ->first();
+        $this->assertNotNull($pivot);
+        $this->assertEquals(100, $pivot->stock);
+        $this->assertEquals(100, $product->fresh()->stock);
+    }
+
+    public function test_store_records_initial_mutation_with_warehouse(): void
+    {
+        $this->post(route('products.store'), $this->validPayload());
+
+        $product = Product::latest('id')->first();
+
+        $mutation = StockMutation::where('reference_type', 'product_create')
+            ->where('product_id', $product->id)
+            ->first();
+        $this->assertNotNull($mutation);
+        $this->assertEquals($this->warehouse->id, $mutation->warehouse_id);
+        $this->assertEquals(100, $mutation->qty);
+        $this->assertEquals(0, $mutation->stock_before);
+        $this->assertEquals(100, $mutation->stock_after);
+    }
+
+    public function test_store_uses_requested_warehouse(): void
+    {
+        $other = Warehouse::create([
+            'code' => 'WH-2',
+            'name' => 'Gudang Kedua',
+            'type' => 'branch',
+            'is_active' => true,
+            'sort_order' => 1,
+        ]);
+
+        $this->post(route('products.store'), $this->validPayload(['warehouse_id' => $other->id]))
+            ->assertRedirect(route('products.index'));
+
+        $product = Product::latest('id')->first();
+
+        $this->assertDatabaseHas('product_warehouse', [
+            'product_id' => $product->id,
+            'warehouse_id' => $other->id,
+            'stock' => 100,
+        ]);
+    }
+
+    public function test_update_persists_min_and_max_stock(): void
+    {
+        $product = Product::create([
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi uji.',
+            'category_id' => $this->category->id,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'tax_rate' => 0,
+        ]);
+
+        $payload = [
+            'image' => UploadedFile::fake()->image('product.png'),
+            'barcode' => $product->barcode,
+            'sku' => $product->sku,
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi uji.',
+            'category_id' => $this->category->id,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'tax_rate' => 0,
+            'min_stock' => 25,
+            'max_stock' => 250,
+        ];
+
+        $this->put(route('products.update', $product), $payload)
+            ->assertRedirect(route('products.index'));
+
+        $product = $product->fresh();
+        $this->assertEquals(25, $product->min_stock);
+        $this->assertEquals(250, $product->max_stock);
+    }
+
+    public function test_store_requires_image(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['image']);
+
+        $this->post(route('products.store'), $payload)
+            ->assertSessionHasErrors('image');
+    }
+}

--- a/tests/Feature/Purchasing/GoodsReceivingTest.php
+++ b/tests/Feature/Purchasing/GoodsReceivingTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Feature\Purchasing;
+
+use App\Models\Category;
+use App\Models\GoodsReceiving;
+use App\Models\Product;
+use App\Models\ProductWarehouse;
+use App\Models\PurchaseOrder;
+use App\Models\StockMutation;
+use App\Models\Supplier;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\PurchaseOrderService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GoodsReceivingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->supplier = Supplier::create([
+            'name' => 'Supplier Test',
+            'phone' => '081234567890',
+            'email' => 'supplier@test.com',
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $stock = 100): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Produk '.self::$seq,
+            'sku' => 'SKU-PO-'.self::$seq,
+            'buy_price' => 10000,
+            'sell_price' => 15000,
+            'stock' => $stock,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-PO-'.self::$seq,
+            'description' => 'Deskripsi produk test',
+            'tax_rate' => 0,
+            'category_id' => $this->category->id,
+        ]);
+
+        $product->warehouses()->attach($this->warehouse->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function createOrderedPo(Product $product, int $qty = 10, ?int $warehouseId = null): PurchaseOrder
+    {
+        $service = app(PurchaseOrderService::class);
+
+        $order = $service->createOrder(
+            data: [
+                'supplier_id' => $this->supplier->id,
+                'warehouse_id' => $warehouseId,
+            ],
+            items: [[
+                'product_id' => $product->id,
+                'qty_ordered' => $qty,
+                'unit_price' => 5000,
+            ]],
+            userId: $this->admin->id
+        );
+
+        $service->placeOrder($order);
+
+        return $order->fresh();
+    }
+
+    private function receivingPayload(PurchaseOrder $order, int $qty): array
+    {
+        return [
+            'purchase_order_id' => $order->id,
+            'items' => [[
+                'purchase_order_item_id' => $order->items->first()->id,
+                'qty_received' => $qty,
+            ]],
+        ];
+    }
+
+    public function test_receiving_increments_global_and_warehouse_stock(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+
+        $response = $this->post(route('goods-receivings.store'), $this->receivingPayload($order, 4));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $product = $product->fresh();
+        $this->assertEquals(104, $product->stock);
+
+        $pivot = ProductWarehouse::where('product_id', $product->id)
+            ->where('warehouse_id', $this->warehouse->id)
+            ->first();
+        $this->assertNotNull($pivot);
+        $this->assertEquals(104, $pivot->stock);
+
+        $poItem = $order->items()->first();
+        $this->assertEquals(4, $poItem->qty_received);
+        $this->assertEquals('partial_received', $order->fresh()->status);
+
+        $mutation = StockMutation::where('reference_type', 'goods_receiving')
+            ->where('product_id', $product->id)
+            ->first();
+        $this->assertNotNull($mutation);
+        $this->assertEquals('in', $mutation->mutation_type);
+        $this->assertEquals(4, $mutation->qty);
+        $this->assertEquals(100, $mutation->stock_before);
+        $this->assertEquals(104, $mutation->stock_after);
+    }
+
+    public function test_receiving_rejects_draft_po(): void
+    {
+        $product = $this->createProduct(100);
+        $order = app(PurchaseOrderService::class)->createOrder(
+            data: ['supplier_id' => $this->supplier->id, 'warehouse_id' => $this->warehouse->id],
+            items: [['product_id' => $product->id, 'qty_ordered' => 10, 'unit_price' => 5000]],
+            userId: $this->admin->id
+        );
+
+        $response = $this->post(route('goods-receivings.store'), $this->receivingPayload($order, 4));
+
+        $response->assertSessionHas('error');
+        $this->assertEquals(0, GoodsReceiving::count());
+        $this->assertEquals(100, $product->fresh()->stock);
+        $this->assertEquals('draft', $order->fresh()->status);
+    }
+
+    public function test_receiving_rejects_qty_exceeding_outstanding(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+
+        $response = $this->post(route('goods-receivings.store'), $this->receivingPayload($order, 11));
+
+        $response->assertSessionHas('error');
+        $this->assertEquals(0, GoodsReceiving::count());
+        $this->assertEquals(100, $product->fresh()->stock);
+    }
+
+    public function test_receiving_without_warehouse_still_increments_global_stock(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, null);
+
+        $response = $this->post(route('goods-receivings.store'), $this->receivingPayload($order, 4));
+
+        $response->assertSessionHas('success');
+        $this->assertEquals(104, $product->fresh()->stock);
+        $this->assertEquals('partial_received', $order->fresh()->status);
+    }
+
+    public function test_receiving_with_batch_number_creates_batch_record(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+
+        $payload = $this->receivingPayload($order, 5);
+        $payload['items'][0]['batch_number'] = 'BATCH-001';
+        $payload['items'][0]['expired_at'] = '2027-12-31';
+
+        $response = $this->post(route('goods-receivings.store'), $payload);
+
+        $response->assertSessionHas('success');
+        $this->assertDatabaseHas('product_batches', [
+            'product_id' => $product->id,
+            'warehouse_id' => $this->warehouse->id,
+            'batch_number' => 'BATCH-001',
+            'stock' => 5,
+        ]);
+    }
+
+    public function test_full_receiving_marks_po_completed(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+
+        $this->post(route('goods-receivings.store'), $this->receivingPayload($order, 10));
+
+        $this->assertEquals('completed', $order->fresh()->status);
+        $this->assertNotNull($order->fresh()->completed_at);
+    }
+}


### PR DESCRIPTION
Fix hasil audit bug menyeluruh.

## Stok berkurang saat menerima PO
- `GoodsReceivingService::receive()` sebelumnya memakai `decrement('stock')` untuk barang MASUK → stok berkurang. Diubah ke `increment`, nilai stock_before/stock_after audit diperbaiki.
- Pivot `product_warehouse` kini memakai `firstOrCreate` (sebelumnya `where()->increment` bisa no-op jika baris belum ada).
- Batch record tidak lagi memakai fallback hardcoded `warehouse_id ?? 1`.

## Produk baru tidak terlihat stoknya di POS
- `ProductController::store()` kini membuat baris `product_warehouse` di warehouse default (PUSAT / `warehouse_id` dari request) + mutasi awal membawa warehouse_id. POS membaca stok dari pivot.
- Validasi `image` diwajibkan (sebelumnya null-crash 500 saat simpan tanpa gambar).

## Edit produk tidak menyimpan min/max stock
- Kedua cabang `update()` kini menyimpan `min_stock`/`max_stock` (sebelumnya divalidasi tapi tidak ditulis).

## Tombol tidak bisa diklik (Tambah Produk/Kategori, Terima Barang, dll)
- `Button type="link"` dengan `href` sekarang render Inertia `<Link>` (sebelumnya `<button onClick=undefined>`).
- `Button type="button"` kini menulis atribut `type="button"` (sebelumnya default submit di dalam form).

## Lainnya
- `StockOpnameController::finalize()`: opname per-gudang hanya mengubah pivot gudang tsb, lalu stok global dihitung ulang dari SUM pivot (sebelumnya stok global ditiban ke jumlah fisik satu gudang).
- `GoodsReceivingController::store()`: tolak PO non ordered/partial + validasi batch_number/expired_at.
- `Categories/Edit.jsx`: preview gambar memakai URL accessor langsung.

## Test
- `tests/Feature/Purchasing/GoodsReceivingTest.php` (6 test) — baru.
- `tests/Feature/Products/ProductStoreTest.php` (5 test) — baru.
- Full suite: 195 passed (883 assertions).