### PR TITLE
fix: backport RoleRequest + deploy path to development

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           port: 22
           script: |
             set -e
-            cd /var/www/kasir.aryadwip.com
+            cd /var/www/dikasir.web.id
             export GIT_SSH_COMMAND="ssh -o ConnectTimeout=20 -o BatchMode=yes"
 
             # Ensure deploy user can modify the web root (fix root-owned dirs from manual ops)
@@ -82,7 +82,7 @@ jobs:
             echo "==> Frontend dependencies + build"
             NPM_OK=0
             for i in 1 2 3; do
-              if sudo -u deploy bash -lc 'export PATH=/home/deploy/.nvm/versions/node/v24.15.0/bin:$PATH; cd /var/www/kasir.aryadwip.com && PUPPETEER_SKIP_DOWNLOAD=true npm ci --no-audit --no-fund && npm run build'; then NPM_OK=1; break; fi
+              if sudo -u deploy bash -lc 'export PATH=/home/deploy/.nvm/versions/node/v24.15.0/bin:$PATH; cd /var/www/dikasir.web.id && PUPPETEER_SKIP_DOWNLOAD=true npm ci --no-audit --no-fund && npm run build'; then NPM_OK=1; break; fi
               echo "npm ci/build failed (attempt $i/3), retrying in 8s..."
               sleep 8
             done

--- a/app/Http/Requests/RoleRequest.php
+++ b/app/Http/Requests/RoleRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RoleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('roles')->ignore($this->role?->id)],
+            'selectedPermission' => ['nullable', 'array'],
+            'selectedPermission.*' => ['exists:permissions,id'],
+        ];
+    }
+}


### PR DESCRIPTION
Backport hotfix dari main (b14f288) ke development.

## Isi
- `app/Http/Requests/RoleRequest.php` (baru) — `RoleController` di development sudah meng-import kelas ini tetapi filenya belum ada → store/update role akan 500.
- `.github/workflows/deploy.yml` — path deploy dikoreksi ke `dikasir.web.id`.

Kedua file identik dengan versi di main (verified via git diff). Full suite: 195 passed (883 assertions).