### PR TITLE
fix(security+payment+inventory): integrity overhaul (13 fase)

### DIFF
--- a/app/Console/Commands/InventoryReconcileCommand.php
+++ b/app/Console/Commands/InventoryReconcileCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Product;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class InventoryReconcileCommand extends Command
+{
+    protected $signature = 'inventory:reconcile {--fix : Set products.stock to the sum of per-warehouse stock}';
+
+    protected $description = 'Compare legacy products.stock against the per-warehouse pivot total and report (or fix) mismatches';
+
+    public function handle(): int
+    {
+        $rows = Product::query()
+            ->select('products.id', 'products.title', 'products.stock')
+            ->selectRaw('COALESCE(SUM(product_warehouse.stock), 0) AS pivot_total')
+            ->leftJoin('product_warehouse', 'product_warehouse.product_id', '=', 'products.id')
+            ->groupBy('products.id', 'products.title', 'products.stock')
+            ->get();
+
+        $mismatches = $rows->filter(fn ($row) => (int) $row->stock !== (int) $row->pivot_total);
+
+        if ($mismatches->isEmpty()) {
+            $this->info('Inventory is consistent (products.stock matches per-warehouse totals).');
+
+            return self::SUCCESS;
+        }
+
+        $this->warn("Found {$mismatches->count()} product(s) where products.stock differs from the per-warehouse total.");
+
+        foreach ($mismatches as $row) {
+            $this->line(sprintf(
+                '  #%d %s — products.stock: %d, pivot total: %d',
+                $row->id,
+                $row->title,
+                (int) $row->stock,
+                (int) $row->pivot_total
+            ));
+        }
+
+        if (! $this->option('fix')) {
+            $this->info('Run with --fix to align products.stock to the pivot totals.');
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($mismatches) {
+            foreach ($mismatches as $row) {
+                Product::whereKey($row->id)->update(['stock' => (int) $row->pivot_total]);
+            }
+        });
+
+        $this->info('Fixed: products.stock aligned to per-warehouse totals.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/PosApiController.php
+++ b/app/Http/Controllers/Api/PosApiController.php
@@ -136,6 +136,12 @@ class PosApiController extends Controller
 
         $products = Product::query()
             ->with('category')
+            ->when($warehouseId, function ($q) use ($warehouseId) {
+                $q->whereHas('warehouses', fn ($w) => $w->where('product_warehouse.warehouse_id', $warehouseId)
+                    ->where('product_warehouse.stock', '>', 0));
+            }, function ($q) {
+                $q->where('stock', '>', 0);
+            })
             ->when($request->string('search')->toString(), function ($q, $search) {
                 $q->where(function ($sub) use ($search) {
                     $sub->where('title', 'like', "%{$search}%")

--- a/app/Http/Controllers/Api/PosApiController.php
+++ b/app/Http/Controllers/Api/PosApiController.php
@@ -278,6 +278,11 @@ class PosApiController extends Controller
             $conversionFactor = 1;
         } else {
             $unitId = (int) ($validated['unit_id'] ?? $product->baseUnit()?->id ?? 1);
+
+            if (isset($validated['unit_id']) && ! $product->units()->whereKey($unitId)->exists()) {
+                return $this->error('Satuan tidak valid untuk produk ini.', 422);
+            }
+
             $baseQty = $this->unitConversionService->toBaseUnit($product, $unitId, $validated['qty']);
 
             $availableStock = $warehouseId

--- a/app/Http/Controllers/Api/PosApiController.php
+++ b/app/Http/Controllers/Api/PosApiController.php
@@ -567,6 +567,12 @@ class PosApiController extends Controller
                 $grandTotal = (int) data_get($checkoutPreview, 'summary.grand_total', 0);
                 $changeAmount = $isCashPayment ? max(0, $cashAmount - $grandTotal) : 0;
 
+                if ($isCashPayment && $cashAmount < $grandTotal) {
+                    throw ValidationException::withMessages([
+                        'cash' => 'Uang tunai kurang dari total belanja.',
+                    ]);
+                }
+
                 $transaction = Transaction::create([
                     'cashier_id' => $request->user()->id,
                     'cashier_shift_id' => $activeShift->id,

--- a/app/Http/Controllers/Api/PosApiController.php
+++ b/app/Http/Controllers/Api/PosApiController.php
@@ -637,23 +637,42 @@ class PosApiController extends Controller
                     ]);
 
                     $product = Product::find($cart->product_id);
+                    $warehouseId = $activeShift->warehouse_id;
 
                     if ($product->is_composite) {
                         $product->load('components');
                         foreach ($product->components as $component) {
                             $componentQty = (int) round((float) $component->pivot->qty * $cart->qty);
-                            ProductWarehouse::where([
-                                'product_id' => $component->id,
-                                'warehouse_id' => $activeShift->warehouse_id,
-                            ])->decrement('stock', $componentQty);
+                            $pw = $warehouseId
+                                ? ProductWarehouse::where([
+                                    'product_id' => $component->id,
+                                    'warehouse_id' => $warehouseId,
+                                ])->lockForUpdate()->first()
+                                : null;
+                            $available = $pw ? (int) $pw->stock : (int) $component->stock;
+                            if ($available < $componentQty) {
+                                throw ValidationException::withMessages(['stock' => "Stok komponen {$component->title} tidak mencukupi. Tersedia: {$available}."]);
+                            }
+                            if ($pw) {
+                                $pw->decrement('stock', $componentQty);
+                            }
                             $component->decrement('stock', $componentQty);
                         }
                     } else {
                         $baseQty = (int) round($cart->qty * (float) ($cart->conversion_factor ?? 1));
-                        ProductWarehouse::where([
-                            'product_id' => $product->id,
-                            'warehouse_id' => $activeShift->warehouse_id,
-                        ])->decrement('stock', $baseQty);
+                        $pw = $warehouseId
+                            ? ProductWarehouse::where([
+                                'product_id' => $product->id,
+                                'warehouse_id' => $warehouseId,
+                            ])->lockForUpdate()->first()
+                            : null;
+                        $available = $pw ? (int) $pw->stock : (int) $product->stock;
+                        if ($available < $baseQty) {
+                            throw ValidationException::withMessages(['stock' => "Stok {$product->title} tidak mencukupi. Tersedia: {$available}."]);
+                        }
+                        if ($pw) {
+                            $pw->decrement('stock', $baseQty);
+                        }
                         $product->decrement('stock', $baseQty);
                     }
                 }

--- a/app/Http/Controllers/Apps/DiscountApprovalController.php
+++ b/app/Http/Controllers/Apps/DiscountApprovalController.php
@@ -57,16 +57,33 @@ class DiscountApprovalController extends Controller
     private function logAndUpdate(Transaction $transaction, string $status, ?string $notes = null): void
     {
         \DB::transaction(function () use ($transaction, $status, $notes) {
-            $transaction->update([
+            // ponytail: approval only settles the approval state — payment stays tied to the actual method.
+            // grand_total already excludes the manual discount (LoyaltyService), so denying re-adds it.
+            $paymentStatus = match ($transaction->payment_method) {
+                'cash' => 'paid',
+                'pay_later' => 'unpaid',
+                default => 'pending',
+            };
+
+            $updates = [
                 'discount_approval_status' => $status,
                 'discount_approved_by' => auth()->id(),
                 'discount_approved_at' => now(),
-                'payment_status' => $status === 'approved' ? 'paid' : 'paid',
-            ]);
+            ];
+
+            $deniedDiscount = (int) $transaction->discount;
 
             if ($status === 'denied') {
-                $transaction->decrement('grand_total', $transaction->discount ?? 0);
-                $transaction->update(['discount' => 0]);
+                $updates['discount'] = 0;
+                $updates['payment_status'] = 'unpaid';
+            } else {
+                $updates['payment_status'] = $paymentStatus;
+            }
+
+            $transaction->update($updates);
+
+            if ($status === 'denied' && $deniedDiscount > 0) {
+                $transaction->increment('grand_total', $deniedDiscount);
             }
 
             DiscountApprovalLog::where('transaction_id', $transaction->id)

--- a/app/Http/Controllers/Apps/GoodsReceivingController.php
+++ b/app/Http/Controllers/Apps/GoodsReceivingController.php
@@ -78,7 +78,13 @@ class GoodsReceivingController extends Controller
             return back()->with('error', 'Hanya PO berstatus ordered/partial yang dapat diterima.');
         }
 
+        $seen = [];
         foreach ($data['items'] as $item) {
+            if (in_array($item['purchase_order_item_id'], $seen)) {
+                return back()->with('error', 'Item PO duplikat dalam satu penerimaan.');
+            }
+            $seen[] = $item['purchase_order_item_id'];
+
             $poItem = $order->items->firstWhere('id', $item['purchase_order_item_id']);
             if (! $poItem) {
                 return back()->with('error', 'Item tidak ditemukan di PO.');

--- a/app/Http/Controllers/Apps/PayableController.php
+++ b/app/Http/Controllers/Apps/PayableController.php
@@ -10,6 +10,7 @@ use App\Models\Supplier;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
 class PayableController extends Controller
@@ -159,12 +160,17 @@ class PayableController extends Controller
             'note' => ['nullable', 'string', 'max:500'],
         ]);
 
-        $remaining = $payable->remaining;
-        if ($validated['amount'] > $remaining) {
-            return back()->with('error', 'Nominal melebihi sisa hutang.');
-        }
-
         DB::transaction(function () use ($validated, $payable, $request) {
+            // ponytail: lock the payable row so concurrent payments cannot double-apply past the remaining balance
+            $payable = Payable::whereKey($payable->id)->lockForUpdate()->firstOrFail();
+
+            $remaining = $payable->remaining;
+            if ($validated['amount'] > $remaining) {
+                throw ValidationException::withMessages([
+                    'amount' => 'Nominal melebihi sisa hutang.',
+                ]);
+            }
+
             PayablePayment::create([
                 'payable_id' => $payable->id,
                 'paid_at' => $validated['paid_at'],

--- a/app/Http/Controllers/Apps/ReceivableController.php
+++ b/app/Http/Controllers/Apps/ReceivableController.php
@@ -9,6 +9,7 @@ use App\Models\ReceivablePayment;
 use App\Services\ReceivableService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
 class ReceivableController extends Controller
@@ -86,12 +87,17 @@ class ReceivableController extends Controller
             'note' => ['nullable', 'string', 'max:500'],
         ]);
 
-        $remaining = $receivable->remaining;
-        if ($validated['amount'] > $remaining) {
-            return back()->with('error', 'Nominal melebihi sisa piutang.');
-        }
-
         DB::transaction(function () use ($validated, $receivable, $request) {
+            // ponytail: lock the receivable row so concurrent payments cannot double-apply past the remaining balance
+            $receivable = Receivable::whereKey($receivable->id)->lockForUpdate()->firstOrFail();
+
+            $remaining = $receivable->remaining;
+            if ($validated['amount'] > $remaining) {
+                throw ValidationException::withMessages([
+                    'amount' => 'Nominal melebihi sisa piutang.',
+                ]);
+            }
+
             ReceivablePayment::create([
                 'receivable_id' => $receivable->id,
                 'paid_at' => $validated['paid_at'],

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -31,6 +31,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
 class TransactionController extends Controller
@@ -629,6 +630,12 @@ class TransactionController extends Controller
             $appliedManualDiscount = (int) data_get($checkoutPreview, 'summary.manual_discount_total', 0);
             $grandTotal = (int) data_get($checkoutPreview, 'summary.grand_total', 0);
             $changeAmount = $isCashPayment ? max(0, $cashAmount - $grandTotal) : 0;
+
+            if ($isCashPayment && $cashAmount < $grandTotal) {
+                throw ValidationException::withMessages([
+                    'cash' => 'Uang tunai kurang dari total belanja.',
+                ]);
+            }
 
             $transaction = Transaction::create([
                 'cashier_id' => auth()->user()->id,

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -734,35 +734,77 @@ class TransactionController extends Controller
                 ]);
 
                 $product = Product::find($cart->product_id);
+                $warehouseId = $activeShift->warehouse_id;
 
                 if ($product->is_composite) {
                     $product->load('components');
                     foreach ($product->components as $component) {
                         $componentQty = (int) round((float) $component->pivot->qty * $cart->qty);
-                        ProductWarehouse::where([
-                            'product_id' => $component->id,
-                            'warehouse_id' => $activeShift->warehouse_id,
-                        ])->decrement('stock', $componentQty);
+                        // ponytail: lock pivot row, re-check stock inside the transaction to prevent overselling
+                        $pw = $warehouseId
+                            ? ProductWarehouse::where([
+                                'product_id' => $component->id,
+                                'warehouse_id' => $warehouseId,
+                            ])->lockForUpdate()->first()
+                            : null;
+                        $available = $pw ? (int) $pw->stock : (int) $component->stock;
+                        if ($available < $componentQty) {
+                            throw ValidationException::withMessages(['stock' => "Stok komponen {$component->title} tidak mencukupi. Tersedia: {$available}."]);
+                        }
+                        if ($pw) {
+                            $pw->decrement('stock', $componentQty);
+                        }
                         $component->decrement('stock', $componentQty);
                     }
                 } else {
                     $baseQty = (int) round($cart->qty * (float) ($cart->conversion_factor ?? 1));
-                    ProductWarehouse::where([
-                        'product_id' => $product->id,
-                        'warehouse_id' => $activeShift->warehouse_id,
-                    ])->decrement('stock', $baseQty);
+
+                    // ponytail: lock pivot row and re-check stock at checkout time (cart add only checks once)
+                    $pw = $warehouseId
+                        ? ProductWarehouse::where([
+                            'product_id' => $product->id,
+                            'warehouse_id' => $warehouseId,
+                        ])->lockForUpdate()->first()
+                        : null;
+                    $available = $pw ? (int) $pw->stock : (int) $product->stock;
+                    if ($available < $baseQty) {
+                        throw ValidationException::withMessages(['stock' => "Stok {$product->title} tidak mencukupi. Tersedia: {$available}."]);
+                    }
+                    if ($pw) {
+                        $pw->decrement('stock', $baseQty);
+                    }
                     $product->decrement('stock', $baseQty);
 
-                    // FEFO: consume batch stock when the product has batches, else legacy path unchanged
-                    if (ProductBatch::where('product_id', $product->id)
-                        ->where('warehouse_id', $activeShift->warehouse_id)
-                        ->where('stock', '>', 0)->exists()) {
-                        $allocations = $this->batchService->allocate($product, $activeShift->warehouse_id, $baseQty);
-                        foreach ($allocations as $allocation) {
-                            ProductBatch::where('id', $allocation['batch_id'])->decrement('stock', $allocation['qty']);
-                        }
-                        if ($allocations !== []) {
-                            $detail->update(['product_batch_id' => $allocations[0]['batch_id']]);
+                    // FEFO: consume non-expired batch stock (locked). Products with partial batch coverage are rejected.
+                    if ($warehouseId) {
+                        $batches = ProductBatch::where('product_id', $product->id)
+                            ->where('warehouse_id', $warehouseId)
+                            ->where('stock', '>', 0)
+                            ->where(function (Builder $q) {
+                                $q->whereNull('expired_at')->orWhere('expired_at', '>', now());
+                            })
+                            ->orderBy('expired_at')
+                            ->orderBy('received_at')
+                            ->lockForUpdate()
+                            ->get();
+
+                        if ($batches->isNotEmpty()) {
+                            $covered = (int) $batches->sum('stock');
+                            if ($covered < $baseQty) {
+                                throw ValidationException::withMessages(['stock' => "Stok batch {$product->title} tidak mencukupi. Tersedia: {$covered}."]);
+                            }
+                            $remaining = $baseQty;
+                            $firstBatchId = null;
+                            foreach ($batches as $batch) {
+                                if ($remaining <= 0) {
+                                    break;
+                                }
+                                $take = min((int) $batch->stock, $remaining);
+                                $batch->decrement('stock', $take);
+                                $remaining -= $take;
+                                $firstBatchId ??= $batch->id;
+                            }
+                            $detail->update(['product_batch_id' => $firstBatchId]);
                         }
                     }
                 }

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -803,6 +803,11 @@ class TransactionController extends Controller
                                 $batch->decrement('stock', $take);
                                 $remaining -= $take;
                                 $firstBatchId ??= $batch->id;
+                                // record every batch consumed so multi-batch lines are fully traceable
+                                $detail->batchAllocations()->create([
+                                    'product_batch_id' => $batch->id,
+                                    'qty' => $take,
+                                ]);
                             }
                             $detail->update(['product_batch_id' => $firstBatchId]);
                         }

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -606,13 +606,7 @@ class TransactionController extends Controller
             }
         }
 
-        $length = 10;
-        $random = '';
-        for ($i = 0; $i < $length; $i++) {
-            $random .= rand(0, 1) ? rand(0, 9) : chr(rand(ord('a'), ord('z')));
-        }
-
-        $invoice = 'TRX-'.Str::upper($random);
+        $invoice = 'TRX-'.Str::upper(Str::random(10));
         $isCashPayment = empty($paymentGateway) && ! $isPayLater;
         $manualDiscount = max(0, (int) $request->input('discount', 0));
         $shippingCost = max(0, (int) $request->input('shipping_cost', 0));

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -241,10 +241,16 @@ class TransactionController extends Controller
      */
     public function addToCart(Request $request)
     {
+        $validated = $request->validate([
+            'product_id' => ['required', 'integer', 'exists:products,id'],
+            'qty' => ['required', 'numeric', 'min:0.01'],
+            'unit_id' => ['nullable', 'integer'],
+        ]);
+
         $activeShift = $this->cashierShiftService->getActiveShiftForUser(auth()->user()->id);
         $warehouseId = $activeShift?->warehouse_id;
 
-        $product = Product::whereId($request->product_id)->first();
+        $product = Product::whereId($validated['product_id'])->first();
 
         if (! $product) {
             return redirect()->back()->with('error', 'Product not found.');
@@ -257,7 +263,7 @@ class TransactionController extends Controller
         if ($product->is_composite) {
             $product->load('components');
             foreach ($product->components as $component) {
-                $needed = (float) $component->pivot->qty * $request->qty;
+                $needed = (float) $component->pivot->qty * $validated['qty'];
                 $whProduct = $component->warehouses()->where('warehouse_id', $warehouseId)->first();
                 $avail = $whProduct?->pivot->stock ?? 0;
                 if ($avail < $needed) {
@@ -267,9 +273,15 @@ class TransactionController extends Controller
             // Composite price = sum component prices
             $sellPrice = (int) $product->components->sum(fn ($c) => $c->sell_price * (float) $c->pivot->qty);
         } else {
-            $unitId = (int) ($request->unit_id ?: $product->baseUnit()?->id ?: 1);
+            $unitId = (int) (($validated['unit_id'] ?? null) ?: $product->baseUnit()?->id ?: 1);
+
+            // Reject an explicitly provided unit that does not belong to this product
+            if (! empty($validated['unit_id'] ?? null) && ! $product->units()->whereKey($unitId)->exists()) {
+                return redirect()->back()->with('error', 'Satuan tidak valid untuk produk ini.');
+            }
+
             $unitConversion = app(UnitConversionService::class);
-            $baseQty = $unitConversion->toBaseUnit($product, $unitId, $request->qty);
+            $baseQty = $unitConversion->toBaseUnit($product, $unitId, $validated['qty']);
 
             $availableStock = $warehouseId
                 ? (int) ($product->warehouses()->where('warehouse_id', $warehouseId)->first()?->pivot->stock ?? 0)
@@ -288,24 +300,24 @@ class TransactionController extends Controller
         }
 
         $cart = Cart::with('product')
-            ->where('product_id', $request->product_id)
+            ->where('product_id', $validated['product_id'])
             ->where('cashier_id', auth()->user()->id)
             ->active()
             ->first();
 
         if ($cart) {
-            $cart->increment('qty', $request->qty);
+            $cart->increment('qty', $validated['qty']);
             $cart->price = $sellPrice * $cart->qty;
             $cart->save();
         } else {
             Cart::create([
                 'cashier_id' => auth()->user()->id,
                 'warehouse_id' => $warehouseId,
-                'product_id' => $request->product_id,
+                'product_id' => $validated['product_id'],
                 'unit_id' => $unitId,
                 'conversion_factor' => $conversionFactor,
-                'qty' => $request->qty,
-                'price' => $sellPrice * $request->qty,
+                'qty' => $validated['qty'],
+                'price' => $sellPrice * $validated['qty'],
             ]);
         }
 
@@ -320,7 +332,11 @@ class TransactionController extends Controller
      */
     public function destroyCart($cart_id)
     {
-        $cart = Cart::with('product')->whereId($cart_id)->first();
+        $cart = Cart::with('product')
+            ->whereId($cart_id)
+            ->where('cashier_id', auth()->user()->id)
+            ->active()
+            ->first();
 
         if ($cart) {
             $cart->delete();
@@ -360,21 +376,41 @@ class TransactionController extends Controller
             ], 404);
         }
 
-        // Check stock availability
-        $availableStock = $warehouseId
-            ? (int) ($cart->product->warehouses()->where('warehouse_id', $warehouseId)->first()?->pivot->stock ?? 0)
-            : (int) $cart->product->stock;
+        $product = $cart->product;
 
-        if ($availableStock < $request->qty) {
+        if (! $product) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Produk tidak ditemukan',
+            ], 404);
+        }
+
+        if ($product->is_composite) {
+            $product->load('components');
+        }
+
+        // Check stock availability (convert display qty to base qty for the cart's unit)
+        $unitConversion = app(UnitConversionService::class);
+        $baseQty = $product->is_composite
+            ? (int) $request->qty
+            : $unitConversion->toBaseUnit($product, (int) $cart->unit_id, $request->qty);
+
+        $availableStock = $warehouseId
+            ? (int) ($product->warehouses()->where('warehouse_id', $warehouseId)->first()?->pivot->stock ?? 0)
+            : (int) $product->stock;
+
+        if ($availableStock < $baseQty) {
             return response()->json([
                 'success' => false,
                 'message' => 'Stok tidak mencukupi. Tersedia: '.$availableStock,
             ], 422);
         }
 
-        // Update quantity and price
+        // Update quantity and price (derive price from DB, not from request/global sell_price)
         $cart->qty = $request->qty;
-        $cart->price = $cart->product->sell_price * $request->qty;
+        $cart->price = $product->is_composite
+            ? (int) $product->components->sum(fn ($c) => $c->sell_price * (float) $c->pivot->qty) * $request->qty
+            : $unitConversion->getSellPrice($product, (int) $cart->unit_id) * $request->qty;
         $cart->save();
 
         return back()->with('success', 'Quantity updated successfully');

--- a/app/Http/Controllers/Apps/TransactionController.php
+++ b/app/Http/Controllers/Apps/TransactionController.php
@@ -973,6 +973,24 @@ class TransactionController extends Controller
                 ->with('error', 'Transaksi sudah dibayar.');
         }
 
+        if ($transaction->payment_method !== 'bank_transfer') {
+            return redirect()
+                ->back()
+                ->with('error', 'Hanya transaksi transfer bank yang dapat dikonfirmasi pembayarannya.');
+        }
+
+        if (! $transaction->bank_account_id) {
+            return redirect()
+                ->back()
+                ->with('error', 'Transaksi transfer bank belum memiliki rekening tujuan.');
+        }
+
+        if (! in_array($transaction->payment_status, ['pending', 'pending_approval'], true)) {
+            return redirect()
+                ->back()
+                ->with('error', 'Status transaksi tidak dapat dikonfirmasi saat ini.');
+        }
+
         $beforeStatus = $transaction->payment_status;
         $transaction->update([
             'payment_status' => 'paid',

--- a/app/Http/Controllers/DineMenuController.php
+++ b/app/Http/Controllers/DineMenuController.php
@@ -34,7 +34,20 @@ class DineMenuController extends Controller
             ->with(['category', 'units.unit'])
             ->get();
 
-        $products = $this->pricingService->previewProducts($products);
+        // ponytail: previewProducts() returns arrays keyed by product id (pricing fields only) — merge the effective price back onto model-shaped payloads the menu page expects (id/title/image/category_id/sell_price)
+        $previews = $this->pricingService->previewProducts($products);
+
+        $products = $products->map(function (Product $product) use ($previews) {
+            $preview = $previews->get($product->id);
+
+            return [
+                'id' => $product->id,
+                'title' => $product->title,
+                'image' => $product->image,
+                'category_id' => $product->category_id,
+                'sell_price' => (int) ($preview['effective_unit_price'] ?? $product->sell_price),
+            ];
+        })->values();
 
         $storeName = Setting::get('store_name', 'Restoran');
         $storeLogo = Setting::get('store_logo');

--- a/app/Http/Controllers/DineOrderController.php
+++ b/app/Http/Controllers/DineOrderController.php
@@ -9,7 +9,6 @@ use App\Models\Setting;
 use App\Services\Payments\PaymentGatewayManager;
 use App\Services\PricingService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 
@@ -31,22 +30,40 @@ class DineOrderController extends Controller
             'items.*.unit_id' => ['nullable', 'exists:units,id'],
             'items.*.note' => ['nullable', 'string', 'max:255'],
             'notes' => ['nullable', 'string', 'max:500'],
-            'payment_option' => ['required', 'in:pay_at_counter,pay_online'],
+            // ponytail: online payment (gateway + webhook) is not wired yet — enforce counter payment only
+            'payment_option' => ['required', 'in:pay_at_counter'],
         ]);
 
         $items = collect($validated['items']);
         $productIds = $items->pluck('product_id')->toArray();
 
-        $products = Product::whereIn('id', $productIds)->get();
-        $products = $this->pricingService->previewProducts($products);
+        $productModels = Product::with('components')
+            ->whereIn('id', $productIds)
+            ->get()
+            ->keyBy('id');
 
-        $priceMap = $products->keyBy('id')->map(fn($p) => $p->sell_price);
+        $previews = $this->pricingService->previewProducts($productModels);
 
         $subtotal = 0;
         $orderItems = [];
 
         foreach ($items as $item) {
-            $price = $priceMap[$item['product_id']] ?? 0;
+            $product = $productModels->get($item['product_id']);
+            if (! $product) {
+                continue;
+            }
+
+            // Server-side availability check against global stock (tables have no warehouse context).
+            $available = $product->is_composite
+                ? $product->compositeStock()
+                : (int) $product->stock;
+
+            if ($available < $item['qty']) {
+                return back()->with('error', "Stok {$product->title} tidak mencukupi (tersedia: {$available}).");
+            }
+
+            $preview = $previews->get($product->id);
+            $price = (int) ($preview['effective_unit_price'] ?? $product->sell_price);
             $subtotal += $price * $item['qty'];
             $orderItems[] = [
                 'product_id' => $item['product_id'],
@@ -150,7 +167,7 @@ class DineOrderController extends Controller
             return false;
         }
 
-        $hashString = $orderId . $status . $serverKey;
+        $hashString = $orderId.$status.$serverKey;
         $expectedSignature = hash('sha512', $hashString);
 
         return hash_equals($expectedSignature, $signatureKey);

--- a/app/Http/Controllers/DineOrderController.php
+++ b/app/Http/Controllers/DineOrderController.php
@@ -122,9 +122,17 @@ class DineOrderController extends Controller
 
     public function statusCheck(string $accessToken)
     {
-        $order = DineOrder::with(['items.product'])
-            ->where('access_token', $accessToken)
-            ->first(['id', 'status', 'payment_option', 'payment_status', 'subtotal', 'item_count', 'notes', 'created_at', 'submitted_at']);
+        $order = DineOrder::where('access_token', $accessToken)
+            ->first(['id', 'status', 'payment_option', 'payment_status', 'subtotal', 'item_count', 'updated_at']);
+
+        if (! $order) {
+            return response()->json(['message' => 'Pesanan tidak ditemukan.'], 404);
+        }
+
+        // ponytail: the URL token is the only auth factor — poll access is bounded by a 24h window and a rate limit on the route
+        if ($order->updated_at->lt(now()->subHours(24))) {
+            return response()->json(['message' => 'Pesanan sudah kedaluwarsa.'], 410);
+        }
 
         return response()->json(['order' => $order]);
     }

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -8,6 +8,7 @@ use App\Models\Setting;
 use App\Models\Transaction;
 use App\Services\ThermalPrintService;
 use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\Request;
 use Picqer\Barcode\BarcodeGeneratorPNG;
 
 class DocumentController extends Controller
@@ -78,11 +79,24 @@ class DocumentController extends Controller
     }
 
     /**
-     * Public version of invoice (no auth needed).
+     * Public version of invoice (no auth needed, but requires the transaction access token).
      */
-    public function publicInvoice(string $invoice)
+    public function publicInvoice(string $invoice, Request $request)
     {
-        return $this->invoice($invoice);
+        $this->ensureFontDirectory();
+
+        $transaction = Transaction::with(['details.product', 'cashier', 'customer'])
+            ->where('invoice', $invoice)
+            ->where('access_token', $request->query('token'))
+            ->firstOrFail();
+
+        $pdf = Pdf::loadView('pdf.invoice', [
+            'transaction' => $transaction,
+            'store' => $this->storeProfile(),
+            'barcode' => $this->barcode($transaction->invoice),
+        ])->setPaper('a4');
+
+        return $pdf->stream("invoice-{$transaction->invoice}.pdf");
     }
 
     public function receipt(string $invoice, string $size = '80')

--- a/app/Models/ProductBatch.php
+++ b/app/Models/ProductBatch.php
@@ -38,4 +38,9 @@ class ProductBatch extends Model
     {
         return $q->where('expired_at', '<', now())->where('stock', '>', 0);
     }
+
+    public function transactionDetailAllocations()
+    {
+        return $this->hasMany(TransactionDetailBatchAllocation::class);
+    }
 }

--- a/app/Models/TransactionDetail.php
+++ b/app/Models/TransactionDetail.php
@@ -72,4 +72,9 @@ class TransactionDetail extends Model
     {
         return $this->hasMany(SalesReturnItem::class);
     }
+
+    public function batchAllocations()
+    {
+        return $this->hasMany(TransactionDetailBatchAllocation::class);
+    }
 }

--- a/app/Models/TransactionDetailBatchAllocation.php
+++ b/app/Models/TransactionDetailBatchAllocation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TransactionDetailBatchAllocation extends Model
+{
+    protected $fillable = [
+        'transaction_detail_id',
+        'product_batch_id',
+        'qty',
+    ];
+
+    protected $casts = [
+        'qty' => 'integer',
+    ];
+
+    public function transactionDetail()
+    {
+        return $this->belongsTo(TransactionDetail::class);
+    }
+
+    public function productBatch()
+    {
+        return $this->belongsTo(ProductBatch::class);
+    }
+}

--- a/app/Services/DineOrderService.php
+++ b/app/Services/DineOrderService.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Models\CashierShift;
 use App\Models\DineOrder;
 use App\Models\ProductWarehouse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 class DineOrderService
 {
@@ -14,35 +16,66 @@ class DineOrderService
 
     public function accept(DineOrder $order): void
     {
-        $order->update(['status' => DineOrder::STATUS_ACCEPTED]);
-
         $cashierId = $order->cashier_id ?? auth()->id();
         $shift = CashierShift::where('user_id', $cashierId)->open()->first();
 
+        // ponytail: without an open shift there is no warehouse context to take stock from — refuse instead of accepting an order whose stock is never decremented
         if (! $shift) {
-            return;
+            throw ValidationException::withMessages([
+                'shift' => 'Tidak ada shift kasir aktif. Buka shift terlebih dahulu sebelum menerima pesanan.',
+            ]);
         }
 
         $warehouseId = $shift->warehouse_id;
 
-        foreach ($order->items as $item) {
-            $product = $item->product;
+        DB::transaction(function () use ($order, $warehouseId) {
+            // ponytail: lock the order row so accept cannot race with a second accept/reject
+            $order = DineOrder::with('items.product.components')->whereKey($order->id)->lockForUpdate()->firstOrFail();
 
-            if ($product->is_composite) {
-                foreach ($product->components as $component) {
-                    $componentProduct = $component->componentProduct;
-                    $componentProduct->decrement('stock', $item->qty * $component->qty);
-                    ProductWarehouse::where('product_id', $componentProduct->id)
+            foreach ($order->items as $item) {
+                $product = $item->product;
+
+                if ($product->is_composite) {
+                    foreach ($product->components as $component) {
+                        $componentQty = $item->qty * (int) round($component->pivot->qty);
+
+                        $pw = ProductWarehouse::where('product_id', $component->id)
+                            ->where('warehouse_id', $warehouseId)
+                            ->lockForUpdate()
+                            ->first();
+
+                        $available = $pw ? (int) $pw->stock : (int) $component->stock;
+
+                        if ($available < $componentQty) {
+                            throw ValidationException::withMessages([
+                                'stock' => "Stok komponen {$component->title} tidak mencukupi (tersedia: {$available}).",
+                            ]);
+                        }
+
+                        $pw?->decrement('stock', $componentQty);
+                        $component->decrement('stock', $componentQty);
+                    }
+                } else {
+                    $pw = ProductWarehouse::where('product_id', $product->id)
                         ->where('warehouse_id', $warehouseId)
-                        ->decrement('stock', $item->qty * $component->qty);
+                        ->lockForUpdate()
+                        ->first();
+
+                    $available = $pw ? (int) $pw->stock : (int) $product->stock;
+
+                    if ($available < $item->qty) {
+                        throw ValidationException::withMessages([
+                            'stock' => "Stok {$product->title} tidak mencukupi (tersedia: {$available}).",
+                        ]);
+                    }
+
+                    $pw?->decrement('stock', $item->qty);
+                    $product->decrement('stock', $item->qty);
                 }
-            } else {
-                $product->decrement('stock', $item->qty);
-                ProductWarehouse::where('product_id', $product->id)
-                    ->where('warehouse_id', $warehouseId)
-                    ->decrement('stock', $item->qty);
             }
-        }
+
+            $order->update(['status' => DineOrder::STATUS_ACCEPTED]);
+        });
     }
 
     public function reject(DineOrder $order, ?string $reason = null): void

--- a/app/Services/GoodsReceivingService.php
+++ b/app/Services/GoodsReceivingService.php
@@ -10,6 +10,7 @@ use App\Models\ProductWarehouse;
 use App\Models\PurchaseOrder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class GoodsReceivingService
 {
@@ -33,6 +34,15 @@ class GoodsReceivingService
     public function receive(PurchaseOrder $order, array $items, ?string $notes, int $userId): GoodsReceiving
     {
         return DB::transaction(function () use ($order, $items, $notes, $userId) {
+            // ponytail: lock the order + its items so concurrent receipts cannot double-consume the same PO item
+            $order = PurchaseOrder::with('items')->whereKey($order->id)->lockForUpdate()->firstOrFail();
+
+            if (! in_array($order->status, ['ordered', 'partial_received'])) {
+                throw ValidationException::withMessages([
+                    'purchase_order_id' => 'Hanya PO berstatus ordered/partial yang dapat diterima.',
+                ]);
+            }
+
             $receiving = GoodsReceiving::create([
                 'purchase_order_id' => $order->id,
                 'supplier_id' => $order->supplier_id,
@@ -44,8 +54,20 @@ class GoodsReceivingService
             ]);
 
             foreach ($items as $item) {
-                $poItem = $order->items()->findOrFail($item['purchase_order_item_id']);
+                $poItem = $order->items->firstWhere('id', $item['purchase_order_item_id']);
+                if (! $poItem) {
+                    throw ValidationException::withMessages([
+                        'items' => 'Item tidak ditemukan di PO.',
+                    ]);
+                }
                 $qtyReceived = (int) $item['qty_received'];
+
+                $outstanding = $poItem->qty_ordered - $poItem->qty_received;
+                if ($qtyReceived > $outstanding) {
+                    throw ValidationException::withMessages([
+                        'items' => "Qty diterima melebihi sisa item {$poItem->product_id}.",
+                    ]);
+                }
 
                 GoodsReceivingItem::create([
                     'goods_receiving_id' => $receiving->id,

--- a/app/Services/GoodsReceivingService.php
+++ b/app/Services/GoodsReceivingService.php
@@ -8,6 +8,7 @@ use App\Models\Payable;
 use App\Models\ProductBatch;
 use App\Models\ProductWarehouse;
 use App\Models\PurchaseOrder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -33,107 +34,112 @@ class GoodsReceivingService
 
     public function receive(PurchaseOrder $order, array $items, ?string $notes, int $userId): GoodsReceiving
     {
-        return DB::transaction(function () use ($order, $items, $notes, $userId) {
-            // ponytail: lock the order + its items so concurrent receipts cannot double-consume the same PO item
-            $order = PurchaseOrder::with('items')->whereKey($order->id)->lockForUpdate()->firstOrFail();
+        // ponytail: retry only on document_number unique collisions (concurrent receipts pick the same next number)
+        return retry(3, function () use ($order, $items, $notes, $userId) {
+            return DB::transaction(function () use ($order, $items, $notes, $userId) {
+                // ponytail: lock the order + its items so concurrent receipts cannot double-consume the same PO item
+                $order = PurchaseOrder::with('items')->whereKey($order->id)->lockForUpdate()->firstOrFail();
 
-            if (! in_array($order->status, ['ordered', 'partial_received'])) {
-                throw ValidationException::withMessages([
-                    'purchase_order_id' => 'Hanya PO berstatus ordered/partial yang dapat diterima.',
-                ]);
-            }
-
-            $receiving = GoodsReceiving::create([
-                'purchase_order_id' => $order->id,
-                'supplier_id' => $order->supplier_id,
-                'warehouse_id' => $order->warehouse_id,
-                'document_number' => $this->generateDocumentNumber(),
-                'notes' => $notes,
-                'received_by' => $userId,
-                'received_at' => now(),
-            ]);
-
-            foreach ($items as $item) {
-                $poItem = $order->items->firstWhere('id', $item['purchase_order_item_id']);
-                if (! $poItem) {
+                if (! in_array($order->status, ['ordered', 'partial_received'])) {
                     throw ValidationException::withMessages([
-                        'items' => 'Item tidak ditemukan di PO.',
-                    ]);
-                }
-                $qtyReceived = (int) $item['qty_received'];
-
-                $outstanding = $poItem->qty_ordered - $poItem->qty_received;
-                if ($qtyReceived > $outstanding) {
-                    throw ValidationException::withMessages([
-                        'items' => "Qty diterima melebihi sisa item {$poItem->product_id}.",
+                        'purchase_order_id' => 'Hanya PO berstatus ordered/partial yang dapat diterima.',
                     ]);
                 }
 
-                GoodsReceivingItem::create([
-                    'goods_receiving_id' => $receiving->id,
-                    'purchase_order_item_id' => $poItem->id,
-                    'product_id' => $poItem->product_id,
-                    'qty_received' => $qtyReceived,
-                    'notes' => $item['notes'] ?? null,
-                ]);
-
-                $poItem->increment('qty_received', $qtyReceived);
-
-                $product = $poItem->product;
-                $stockBefore = (int) $product->stock;
-                // Increment legacy stock
-                $product->increment('stock', $qtyReceived);
-                // Increment warehouse pivot stock
-                if ($order->warehouse_id) {
-                    ProductWarehouse::firstOrCreate(
-                        ['product_id' => $product->id, 'warehouse_id' => $order->warehouse_id],
-                        ['stock' => 0]
-                    )->increment('stock', $qtyReceived);
-                }
-
-                // Create batch record
-                if (! empty($item['batch_number']) && $order->warehouse_id) {
-                    ProductBatch::create([
-                        'product_id' => $product->id,
-                        'warehouse_id' => $order->warehouse_id,
-                        'batch_number' => $item['batch_number'],
-                        'expired_at' => $item['expired_at'] ?? null,
-                        'received_at' => now(),
-                        'stock' => $qtyReceived,
-                    ]);
-                }
-
-                $this->stockMutationService->recordPurchaseInbound(
-                    product: $product,
-                    goodsReceiving: $receiving,
-                    qty: $qtyReceived,
-                    stockBefore: $stockBefore,
-                    stockAfter: (int) $product->stock,
-                    notes: 'Penerimaan dari PO '.$order->document_number,
-                    userId: $userId,
-                );
-            }
-
-            $this->updateOrderStatus($order);
-
-            if ($receiving->supplier_id) {
-                $this->createOrUpdatePayable($order, $receiving, $userId);
-            }
-
-            $this->auditLogService->log(
-                event: 'goods_receiving.created',
-                module: 'purchase',
-                auditable: $receiving,
-                description: 'Barang diterima dari PO '.$order->document_number,
-                after: [
-                    'document_number' => $receiving->document_number,
+                $receiving = GoodsReceiving::create([
                     'purchase_order_id' => $order->id,
-                    'total_items' => count($items),
-                ],
-                meta: ['goods_receiving_id' => $receiving->id],
-            );
+                    'supplier_id' => $order->supplier_id,
+                    'warehouse_id' => $order->warehouse_id,
+                    'document_number' => $this->generateDocumentNumber(),
+                    'notes' => $notes,
+                    'received_by' => $userId,
+                    'received_at' => now(),
+                ]);
 
-            return $receiving;
+                foreach ($items as $item) {
+                    $poItem = $order->items->firstWhere('id', $item['purchase_order_item_id']);
+                    if (! $poItem) {
+                        throw ValidationException::withMessages([
+                            'items' => 'Item tidak ditemukan di PO.',
+                        ]);
+                    }
+                    $qtyReceived = (int) $item['qty_received'];
+
+                    $outstanding = $poItem->qty_ordered - $poItem->qty_received;
+                    if ($qtyReceived > $outstanding) {
+                        throw ValidationException::withMessages([
+                            'items' => "Qty diterima melebihi sisa item {$poItem->product_id}.",
+                        ]);
+                    }
+
+                    GoodsReceivingItem::create([
+                        'goods_receiving_id' => $receiving->id,
+                        'purchase_order_item_id' => $poItem->id,
+                        'product_id' => $poItem->product_id,
+                        'qty_received' => $qtyReceived,
+                        'notes' => $item['notes'] ?? null,
+                    ]);
+
+                    $poItem->increment('qty_received', $qtyReceived);
+
+                    $product = $poItem->product;
+                    $stockBefore = (int) $product->stock;
+                    // Increment legacy stock
+                    $product->increment('stock', $qtyReceived);
+                    // Increment warehouse pivot stock
+                    if ($order->warehouse_id) {
+                        ProductWarehouse::firstOrCreate(
+                            ['product_id' => $product->id, 'warehouse_id' => $order->warehouse_id],
+                            ['stock' => 0]
+                        )->increment('stock', $qtyReceived);
+                    }
+
+                    // Create batch record
+                    if (! empty($item['batch_number']) && $order->warehouse_id) {
+                        ProductBatch::create([
+                            'product_id' => $product->id,
+                            'warehouse_id' => $order->warehouse_id,
+                            'batch_number' => $item['batch_number'],
+                            'expired_at' => $item['expired_at'] ?? null,
+                            'received_at' => now(),
+                            'stock' => $qtyReceived,
+                        ]);
+                    }
+
+                    $this->stockMutationService->recordPurchaseInbound(
+                        product: $product,
+                        goodsReceiving: $receiving,
+                        qty: $qtyReceived,
+                        stockBefore: $stockBefore,
+                        stockAfter: (int) $product->stock,
+                        notes: 'Penerimaan dari PO '.$order->document_number,
+                        userId: $userId,
+                    );
+                }
+
+                $this->updateOrderStatus($order);
+
+                if ($receiving->supplier_id) {
+                    $this->createOrUpdatePayable($order, $receiving, $userId);
+                }
+
+                $this->auditLogService->log(
+                    event: 'goods_receiving.created',
+                    module: 'purchase',
+                    auditable: $receiving,
+                    description: 'Barang diterima dari PO '.$order->document_number,
+                    after: [
+                        'document_number' => $receiving->document_number,
+                        'purchase_order_id' => $order->id,
+                        'total_items' => count($items),
+                    ],
+                    meta: ['goods_receiving_id' => $receiving->id],
+                );
+
+                return $receiving;
+            });
+        }, 0, function ($e) {
+            return $e instanceof QueryException && str_contains($e->getMessage(), 'document_number');
         });
     }
 

--- a/app/Services/LoyaltyService.php
+++ b/app/Services/LoyaltyService.php
@@ -11,6 +11,7 @@ use App\Models\Transaction;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class LoyaltyService
 {
@@ -342,11 +343,20 @@ class LoyaltyService
         }
 
         if ($voucher) {
-            $voucher->forceFill([
-                'is_used' => true,
-                'used_at' => now(),
-                'used_transaction_id' => $transaction->id,
-            ])->save();
+            // ponytail: atomic single-use claim — reject when another checkout already used it concurrently
+            $claimed = CustomerVoucher::whereKey($voucher->id)
+                ->where('is_used', false)
+                ->update([
+                    'is_used' => true,
+                    'used_at' => now(),
+                    'used_transaction_id' => $transaction->id,
+                ]);
+
+            if ($claimed !== 1) {
+                throw ValidationException::withMessages([
+                    'voucher_code' => 'Voucher sudah digunakan pada transaksi lain.',
+                ]);
+            }
 
             $this->recordHistory(
                 $customer->fresh(),

--- a/app/Services/StockTransferService.php
+++ b/app/Services/StockTransferService.php
@@ -6,6 +6,7 @@ use App\Models\ProductWarehouse;
 use App\Models\StockMutation;
 use App\Models\StockTransfer;
 use App\Models\StockTransferItem;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -36,40 +37,45 @@ class StockTransferService
             ]);
         }
 
-        return DB::transaction(function () use ($data, $items, $userId) {
-            $transfer = StockTransfer::create([
-                'source_warehouse_id' => $data['source_warehouse_id'],
-                'destination_warehouse_id' => $data['destination_warehouse_id'],
-                'document_number' => $data['document_number'] ?? $this->generateDocumentNumber(),
-                'status' => 'draft',
-                'notes' => $data['notes'] ?? null,
-                'created_by' => $userId,
-            ]);
-
-            foreach ($items as $item) {
-                StockTransferItem::create([
-                    'stock_transfer_id' => $transfer->id,
-                    'product_id' => $item['product_id'],
-                    'qty' => $item['qty'],
-                ]);
-            }
-
-            $this->auditLogService->log(
-                event: 'stock_transfer.created',
-                module: 'stock',
-                auditable: $transfer,
-                description: 'Transfer stok '.$transfer->document_number.' dibuat.',
-                after: [
-                    'document_number' => $transfer->document_number,
-                    'source_warehouse_id' => $transfer->source_warehouse_id,
-                    'destination_warehouse_id' => $transfer->destination_warehouse_id,
+        // ponytail: retry only on document_number unique collisions (concurrent drafts pick the same next number)
+        return retry(3, function () use ($data, $items, $userId) {
+            return DB::transaction(function () use ($data, $items, $userId) {
+                $transfer = StockTransfer::create([
+                    'source_warehouse_id' => $data['source_warehouse_id'],
+                    'destination_warehouse_id' => $data['destination_warehouse_id'],
+                    'document_number' => $data['document_number'] ?? $this->generateDocumentNumber(),
                     'status' => 'draft',
-                    'total_items' => count($items),
-                ],
-                meta: ['stock_transfer_id' => $transfer->id],
-            );
+                    'notes' => $data['notes'] ?? null,
+                    'created_by' => $userId,
+                ]);
 
-            return $transfer;
+                foreach ($items as $item) {
+                    StockTransferItem::create([
+                        'stock_transfer_id' => $transfer->id,
+                        'product_id' => $item['product_id'],
+                        'qty' => $item['qty'],
+                    ]);
+                }
+
+                $this->auditLogService->log(
+                    event: 'stock_transfer.created',
+                    module: 'stock',
+                    auditable: $transfer,
+                    description: 'Transfer stok '.$transfer->document_number.' dibuat.',
+                    after: [
+                        'document_number' => $transfer->document_number,
+                        'source_warehouse_id' => $transfer->source_warehouse_id,
+                        'destination_warehouse_id' => $transfer->destination_warehouse_id,
+                        'status' => 'draft',
+                        'total_items' => count($items),
+                    ],
+                    meta: ['stock_transfer_id' => $transfer->id],
+                );
+
+                return $transfer;
+            });
+        }, 0, function ($e) {
+            return $e instanceof QueryException && str_contains($e->getMessage(), 'document_number');
         });
     }
 

--- a/app/Services/StockTransferService.php
+++ b/app/Services/StockTransferService.php
@@ -75,57 +75,48 @@ class StockTransferService
 
     public function send(StockTransfer $transfer, int $userId): void
     {
-        if (! $transfer->isDraft()) {
-            throw ValidationException::withMessages([
-                'transfer' => 'Hanya transfer dengan status draft yang bisa dikirim.',
-            ]);
-        }
-
         DB::transaction(function () use ($transfer, $userId) {
+            // ponytail: lock the transfer row and re-check status inside the transaction (prevents double-send / send-after-cancel races)
+            $transfer = StockTransfer::whereKey($transfer->id)->lockForUpdate()->firstOrFail();
+
+            if (! $transfer->isDraft()) {
+                throw ValidationException::withMessages([
+                    'transfer' => 'Hanya transfer dengan status draft yang bisa dikirim.',
+                ]);
+            }
+
             $transfer->load('items.product');
             $before = $transfer->replicate();
 
-            // Validate stock availability
+            // Validate stock availability and decrement source warehouse stock (locked rows)
             foreach ($transfer->items as $item) {
-                $wh = ProductWarehouse::where([
+                $pw = ProductWarehouse::where([
                     'product_id' => $item->product_id,
                     'warehouse_id' => $transfer->source_warehouse_id,
-                ])->first();
+                ])->lockForUpdate()->first();
 
-                $available = $wh ? (int) $wh->stock : 0;
+                $available = $pw ? (int) $pw->stock : 0;
                 if ($available < $item->qty) {
                     throw ValidationException::withMessages([
                         'transfer' => "Stok {$item->product->title} tidak mencukupi di gudang asal (tersedia: {$available}).",
                     ]);
                 }
-            }
 
-            // Decrement source warehouse stock
-            foreach ($transfer->items as $item) {
-                $product = $item->product;
-                $pw = ProductWarehouse::where([
-                    'product_id' => $item->product_id,
-                    'warehouse_id' => $transfer->source_warehouse_id,
-                ])->first();
-                $stockBefore = $pw ? (int) $pw->stock : 0;
-                $stockAfter = max(0, $stockBefore - $item->qty);
-
-                ProductWarehouse::where([
-                    'product_id' => $item->product_id,
-                    'warehouse_id' => $transfer->source_warehouse_id,
-                ])->decrement('stock', $item->qty);
-
-                $product->decrement('stock', $item->qty);
+                $stockAfter = $available - $item->qty;
+                if ($pw) {
+                    $pw->decrement('stock', $item->qty);
+                }
+                $item->product->decrement('stock', $item->qty);
 
                 StockMutation::create([
-                    'product_id' => $product->id,
+                    'product_id' => $item->product_id,
                     'warehouse_id' => $transfer->source_warehouse_id,
                     'reference_type' => 'stock_transfer',
                     'reference_id' => $transfer->id,
                     'mutation_type' => 'out',
                     'qty' => $item->qty,
-                    'stock_before' => $stockBefore,
-                    'stock_after' => max(0, $stockBefore - $item->qty),
+                    'stock_before' => $available,
+                    'stock_after' => $stockAfter,
                     'notes' => 'Transfer ke '.$transfer->destinationWarehouse->code,
                     'created_by' => $userId,
                 ]);
@@ -149,21 +140,26 @@ class StockTransferService
 
     public function receive(StockTransfer $transfer, int $userId): void
     {
-        if (! $transfer->isInTransit()) {
-            throw ValidationException::withMessages([
-                'transfer' => 'Hanya transfer dengan status in_transit yang bisa diterima.',
-            ]);
-        }
-
         DB::transaction(function () use ($transfer, $userId) {
+            // ponytail: lock the transfer row and re-check status inside the transaction (prevents double-receive)
+            $transfer = StockTransfer::whereKey($transfer->id)->lockForUpdate()->firstOrFail();
+
+            if (! $transfer->isInTransit()) {
+                throw ValidationException::withMessages([
+                    'transfer' => 'Hanya transfer dengan status in_transit yang bisa diterima.',
+                ]);
+            }
+
             $transfer->load('items.product');
             $before = $transfer->replicate();
 
             // Increment destination warehouse stock + legacy stock
             foreach ($transfer->items as $item) {
                 $product = $item->product;
+                $stockBefore = (int) $product->stock;
 
-                ProductWarehouse::updateOrCreate(
+                // ponytail: firstOrCreate (NOT updateOrCreate with stock=0, which would reset an existing row)
+                ProductWarehouse::firstOrCreate(
                     ['product_id' => $item->product_id, 'warehouse_id' => $transfer->destination_warehouse_id],
                     ['stock' => 0]
                 )->increment('stock', $item->qty);
@@ -177,7 +173,7 @@ class StockTransferService
                     'reference_id' => $transfer->id,
                     'mutation_type' => 'in',
                     'qty' => $item->qty,
-                    'stock_before' => (int) $product->stock - $item->qty,
+                    'stock_before' => $stockBefore,
                     'stock_after' => (int) $product->stock,
                     'notes' => 'Transfer dari '.$transfer->sourceWarehouse->code,
                     'created_by' => $userId,
@@ -203,13 +199,16 @@ class StockTransferService
 
     public function cancel(StockTransfer $transfer, int $userId): void
     {
-        if (! in_array($transfer->status, ['draft', 'in_transit'])) {
-            throw ValidationException::withMessages([
-                'transfer' => 'Hanya transfer draft atau in_transit yang bisa dibatalkan.',
-            ]);
-        }
-
         DB::transaction(function () use ($transfer) {
+            // ponytail: lock the transfer row and re-check status inside the transaction (prevents cancel-after-complete races)
+            $transfer = StockTransfer::whereKey($transfer->id)->lockForUpdate()->firstOrFail();
+
+            if (! in_array($transfer->status, ['draft', 'in_transit'])) {
+                throw ValidationException::withMessages([
+                    'transfer' => 'Hanya transfer draft atau in_transit yang bisa dibatalkan.',
+                ]);
+            }
+
             $before = $transfer->replicate();
             $returnStock = $transfer->isInTransit();
 
@@ -218,12 +217,14 @@ class StockTransferService
                 $transfer->load('items.product');
 
                 foreach ($transfer->items as $item) {
-                    ProductWarehouse::updateOrCreate(
+                    $product = $item->product;
+
+                    // ponytail: firstOrCreate (NOT updateOrCreate with stock=0, which would reset an existing row)
+                    ProductWarehouse::firstOrCreate(
                         ['product_id' => $item->product_id, 'warehouse_id' => $transfer->source_warehouse_id],
                         ['stock' => 0]
                     )->increment('stock', $item->qty);
 
-                    $product = $item->product;
                     $product->increment('stock', $item->qty);
                 }
             }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,8 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Laravel\Sanctum\Exceptions\MissingAbilityException;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
@@ -47,12 +49,20 @@ return Application::configure(basePath: dirname(__DIR__))
             'registration.enabled' => EnsurePublicRegistrationEnabled::class,
             'bot.guard' => EnsureBotGuard::class,
             'step_up' => EnsureRecentPasswordConfirmation::class,
+            'abilities' => CheckAbilities::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->render(function (Throwable $exception, Request $request) {
             if ($exception instanceof ValidationException) {
                 return null;
+            }
+
+            // Authenticated token lacks a required ability → 403, not 401/500.
+            if ($exception instanceof MissingAbilityException) {
+                return response()->json([
+                    'message' => $exception->getMessage() ?: 'Missing required ability.',
+                ], Response::HTTP_FORBIDDEN);
             }
 
             // Session expired / not logged in → redirect to login (bukan 500)

--- a/database/migrations/2026_08_15_000000_create_transaction_detail_batch_allocations_table.php
+++ b/database/migrations/2026_08_15_000000_create_transaction_detail_batch_allocations_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transaction_detail_batch_allocations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('transaction_detail_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_batch_id')->constrained()->cascadeOnDelete();
+            $table->integer('qty');
+            $table->timestamps();
+
+            $table->unique(['transaction_detail_id', 'product_batch_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_detail_batch_allocations');
+    }
+};

--- a/resources/js/Components/Dashboard/AuthDropdown.jsx
+++ b/resources/js/Components/Dashboard/AuthDropdown.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Menu, Transition } from "@headlessui/react";
-import { Link, usePage } from "@inertiajs/react";
-import { IconLogout, IconUserCog } from "@tabler/icons-react";
+import { usePage } from "@inertiajs/react";
+import { IconLogout } from "@tabler/icons-react";
 import { useForm } from "@inertiajs/react";
 import MenuLink from "@/Utils/Menu";
 import LinkItem from "./LinkItem";
@@ -83,11 +83,6 @@ export default function AuthDropdown({ auth, isMobile }) {
                     >
                         <Menu.Items className="absolute rounded-lg w-48 border mt-2 py-2 right-0 z-[100] bg-white dark:bg-gray-950 dark:border-gray-900">
                             <div className="flex flex-col gap-1.5 divide-y divide-gray-100 dark:divide-gray-900">
-                                {/* <Menu.Item>
-                                    <Link href="/apps/profile" className='px-3 py-1.5 text-sm flex items-center gap-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'>
-                                        <IconUserCog strokeWidth={'1.5'} size={'20'} /> Profile
-                                    </Link>
-                                </Menu.Item> */}
                                 <Menu.Item>
                                     <button
                                         onClick={logout}

--- a/resources/js/Pages/Dashboard/Transactions/History.jsx
+++ b/resources/js/Pages/Dashboard/Transactions/History.jsx
@@ -365,7 +365,7 @@ const History = ({ transactions, filters, warehouses = [] }) => {
                                                             `Invoice ${transaction.invoice}: ${route(
                                                                 "transactions.public",
                                                                 transaction.invoice,
-                                                                true
+                                                                { token: transaction.access_token }
                                                             )}`
                                                         )}`}
                                                         target="_blank"
@@ -542,7 +542,8 @@ const History = ({ transactions, filters, warehouses = [] }) => {
                                         <a
                                             href={route(
                                                 "transactions.public",
-                                                transaction.invoice
+                                                transaction.invoice,
+                                                { token: transaction.access_token }
                                             )}
                                             target="_blank"
                                             rel="noopener noreferrer"

--- a/resources/js/Pages/Public/DineMenu.jsx
+++ b/resources/js/Pages/Public/DineMenu.jsx
@@ -5,7 +5,7 @@ import toast from "react-hot-toast";
 
 const fmt = (v) => Number(v || 0).toLocaleString("id-ID", { style: "currency", currency: "IDR", minimumFractionDigits: 0 });
 
-export default function DineMenu({ table, categories, products, selfOrderEnabled, payOnlineEnabled, storeName }) {
+export default function DineMenu({ table, categories, products, selfOrderEnabled, storeName }) {
     const [cart, setCart] = useState([]);
     const [activeCategory, setActiveCategory] = useState("all");
     const [notes, setNotes] = useState("");
@@ -238,18 +238,6 @@ export default function DineMenu({ table, categories, products, selfOrderEnabled
                             >
                                 {submitting ? "Mengirim..." : "Pesan — Bayar di Kasir"}
                             </button>
-                            {payOnlineEnabled && (
-                                <button
-                                    onClick={() => {
-                                        document.getElementById("cart-modal")?.close();
-                                        handleSubmit("pay_online");
-                                    }}
-                                    disabled={submitting}
-                                    className="btn btn-outline border-primary-500 text-primary-600 hover:bg-primary-50"
-                                >
-                                    Pesan — Bayar Online
-                                </button>
-                            )}
                         </div>
                     </div>
                     <form method="dialog" className="modal-backdrop">

--- a/resources/js/Pages/Public/DineOrderStatus.jsx
+++ b/resources/js/Pages/Public/DineOrderStatus.jsx
@@ -26,7 +26,8 @@ export default function DineOrderStatus({ order, table, storeName }) {
                     });
                     const data = await res.json();
                     if (data.order) {
-                        setCurrentOrder(data.order);
+                        // status-check returns minimal scalar fields — merge so items/product rows from the initial render are kept
+                        setCurrentOrder((prev) => ({ ...prev, ...data.order }));
                         if (data.order.status !== "submitted") {
                             clearInterval(interval);
                         }

--- a/resources/js/Utils/Menu.jsx
+++ b/resources/js/Utils/Menu.jsx
@@ -405,7 +405,7 @@ export default function Menu() {
                 },
                 {
                     title: t("sidebar.items.priceLists"),
-                    href: route("price-lists.index"),
+                    href: route("settings.price-lists.index"),
                     active: url.startsWith("/dashboard/settings/price-lists"),
                     icon: <IconListDetails size={20} strokeWidth={1.5} />,
                     permissions: hasAnyPermission(["price-lists-access"]),

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,11 +3,11 @@
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CategoryController;
 use App\Http\Controllers\Api\CustomerController;
+use App\Http\Controllers\Api\PaymentWebhookController;
 use App\Http\Controllers\Api\PosApiController;
 use App\Http\Controllers\Api\ProductController;
 use App\Http\Controllers\Api\SupplierController;
 use App\Http\Controllers\Api\WarehouseController;
-use App\Http\Controllers\Api\PaymentWebhookController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -40,46 +40,71 @@ Route::prefix('v1')->group(function () {
             Route::post('/logout', [AuthController::class, 'logout'])->name('api.auth.logout');
         });
 
-        // Master data
-        Route::apiResource('products', ProductController::class)->names([
-            'index' => 'api.products.index',
-            'store' => 'api.products.store',
-            'show' => 'api.products.show',
-            'update' => 'api.products.update',
-            'destroy' => 'api.products.destroy',
-        ]);
+        // Master data — Sanctum abilities mirror Spatie permission names stamped on the token at login
+        Route::apiResource('products', ProductController::class)
+            ->middlewareFor(['index', 'show'], 'abilities:products-access')
+            ->middlewareFor('store', 'abilities:products-create')
+            ->middlewareFor('update', 'abilities:products-edit')
+            ->middlewareFor('destroy', 'abilities:products-delete')
+            ->names([
+                'index' => 'api.products.index',
+                'store' => 'api.products.store',
+                'show' => 'api.products.show',
+                'update' => 'api.products.update',
+                'destroy' => 'api.products.destroy',
+            ]);
 
-        Route::apiResource('customers', CustomerController::class)->names([
-            'index' => 'api.customers.index',
-            'store' => 'api.customers.store',
-            'show' => 'api.customers.show',
-            'update' => 'api.customers.update',
-            'destroy' => 'api.customers.destroy',
-        ]);
+        Route::apiResource('customers', CustomerController::class)
+            ->middlewareFor(['index', 'show'], 'abilities:customers-access')
+            ->middlewareFor('store', 'abilities:customers-create')
+            ->middlewareFor('update', 'abilities:customers-edit')
+            ->middlewareFor('destroy', 'abilities:customers-delete')
+            ->names([
+                'index' => 'api.customers.index',
+                'store' => 'api.customers.store',
+                'show' => 'api.customers.show',
+                'update' => 'api.customers.update',
+                'destroy' => 'api.customers.destroy',
+            ]);
 
-        Route::apiResource('categories', CategoryController::class)->names([
-            'index' => 'api.categories.index',
-            'store' => 'api.categories.store',
-            'show' => 'api.categories.show',
-            'update' => 'api.categories.update',
-            'destroy' => 'api.categories.destroy',
-        ]);
+        Route::apiResource('categories', CategoryController::class)
+            ->middlewareFor(['index', 'show'], 'abilities:categories-access')
+            ->middlewareFor('store', 'abilities:categories-create')
+            ->middlewareFor('update', 'abilities:categories-edit')
+            ->middlewareFor('destroy', 'abilities:categories-delete')
+            ->names([
+                'index' => 'api.categories.index',
+                'store' => 'api.categories.store',
+                'show' => 'api.categories.show',
+                'update' => 'api.categories.update',
+                'destroy' => 'api.categories.destroy',
+            ]);
 
-        Route::apiResource('warehouses', WarehouseController::class)->names([
-            'index' => 'api.warehouses.index',
-            'store' => 'api.warehouses.store',
-            'show' => 'api.warehouses.show',
-            'update' => 'api.warehouses.update',
-            'destroy' => 'api.warehouses.destroy',
-        ]);
+        Route::apiResource('warehouses', WarehouseController::class)
+            ->middlewareFor(['index', 'show'], 'abilities:warehouses-access')
+            ->middlewareFor('store', 'abilities:warehouses-create')
+            ->middlewareFor('update', 'abilities:warehouses-update')
+            ->middlewareFor('destroy', 'abilities:warehouses-delete')
+            ->names([
+                'index' => 'api.warehouses.index',
+                'store' => 'api.warehouses.store',
+                'show' => 'api.warehouses.show',
+                'update' => 'api.warehouses.update',
+                'destroy' => 'api.warehouses.destroy',
+            ]);
 
-        Route::apiResource('suppliers', SupplierController::class)->names([
-            'index' => 'api.suppliers.index',
-            'store' => 'api.suppliers.store',
-            'show' => 'api.suppliers.show',
-            'update' => 'api.suppliers.update',
-            'destroy' => 'api.suppliers.destroy',
-        ]);
+        Route::apiResource('suppliers', SupplierController::class)
+            ->middlewareFor(['index', 'show'], 'abilities:suppliers-access')
+            ->middlewareFor('store', 'abilities:suppliers-access')
+            ->middlewareFor('update', 'abilities:suppliers-access')
+            ->middlewareFor('destroy', 'abilities:suppliers-access')
+            ->names([
+                'index' => 'api.suppliers.index',
+                'store' => 'api.suppliers.store',
+                'show' => 'api.suppliers.show',
+                'update' => 'api.suppliers.update',
+                'destroy' => 'api.suppliers.destroy',
+            ]);
 
         // POS (mobile kasir)
         Route::prefix('pos')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -401,6 +401,6 @@ Route::group(['prefix' => 'dashboard', 'middleware' => ['auth', 'verified']], fu
 Route::get('/dine/{token}', [DineMenuController::class, 'show'])->name('dine.menu');
 Route::post('/dine/{token}/order', [DineOrderController::class, 'store'])->name('dine-order.store');
 Route::get('/dine-order/{accessToken}', [DineOrderController::class, 'status'])->name('dine-order.status');
-Route::get('/dine-order/{accessToken}/check', [DineOrderController::class, 'statusCheck'])->name('dine-order.status-check');
+Route::get('/dine-order/{accessToken}/check', [DineOrderController::class, 'statusCheck'])->middleware('throttle:30,1')->name('dine-order.status-check');
 
 require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,8 +71,9 @@ Route::get('/dashboard/access', function () {
     return Inertia::render('Dashboard/Access');
 })->middleware(['auth', 'verified'])->name('dashboard.access');
 
-// Public share routes (no login)
+// Public share routes (no login, but require the transaction access token)
 Route::get('/share/transactions/{invoice}', [DocumentController::class, 'publicInvoice'])
+    ->middleware('throttle:10,1')
     ->name('transactions.public');
 
 // Customer portal routes (no login, token-based)

--- a/tests/Feature/Api/ApiAuthorizationTest.php
+++ b/tests/Feature/Api/ApiAuthorizationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeUser(): User
+    {
+        return User::factory()->create();
+    }
+
+    private function actingWithAbilities(User $user, array $abilities): void
+    {
+        $token = $user->createToken('test', $abilities)->plainTextToken;
+        $this->withToken($token);
+    }
+
+    public function test_token_without_master_data_ability_gets_403(): void
+    {
+        $this->actingWithAbilities($this->makeUser(), ['user:read']);
+
+        $this->getJson('/api/v1/products')->assertStatus(403);
+    }
+
+    public function test_read_ability_cannot_write(): void
+    {
+        $this->actingWithAbilities($this->makeUser(), ['user:read', 'products-access']);
+
+        $this->getJson('/api/v1/products')->assertOk();
+
+        $this->postJson('/api/v1/products', [
+            'title' => 'Produk Baru',
+            'barcode' => 'AUTH-NEW-001',
+            'buy_price' => 5000,
+            'sell_price' => 7500,
+        ])->assertStatus(403);
+    }
+
+    public function test_register_token_cannot_delete_master_data(): void
+    {
+        $this->actingWithAbilities($this->makeUser(), ['user:read']);
+
+        $category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => '',
+            'description' => '',
+        ]);
+
+        $product = Product::create([
+            'title' => 'Produk Test',
+            'barcode' => 'AUTH-DEL-001',
+            'sku' => 'SKU-AUTH-DEL-001',
+            'image' => '',
+            'description' => '',
+            'buy_price' => 5000,
+            'sell_price' => 7500,
+            'stock' => 10,
+            'category_id' => $category->id,
+            'tax_rate' => 0,
+        ]);
+
+        $this->deleteJson("/api/v1/products/{$product->id}")->assertStatus(403);
+    }
+
+    public function test_token_with_full_abilities_can_write(): void
+    {
+        $user = $this->makeUser();
+        $category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => '',
+            'description' => '',
+        ]);
+
+        $this->actingWithAbilities($user, ['user:read', 'products-access', 'products-create']);
+
+        $this->postJson('/api/v1/products', [
+            'title' => 'Produk Baru',
+            'barcode' => 'AUTH-NEW-002',
+            'category_id' => $category->id,
+            'buy_price' => 5000,
+            'sell_price' => 7500,
+        ])->assertCreated();
+    }
+}

--- a/tests/Feature/Api/MasterDataApiTest.php
+++ b/tests/Feature/Api/MasterDataApiTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Api;
 
 use App\Models\Category;
 use App\Models\Customer;
-use App\Models\Supplier;
 use App\Models\User;
 use App\Models\Warehouse;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,7 +21,7 @@ class MasterDataApiTest extends TestCase
         parent::setUp();
 
         $this->user = User::factory()->create();
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
     }
 
     public function test_customers_index_paginates_and_searches(): void
@@ -127,11 +126,11 @@ class MasterDataApiTest extends TestCase
     public function test_warehouses_crud(): void
     {
         $response = $this->postJson('/api/v1/warehouses', [
-     'code' => 'WH-A',
-     'name' => 'Gudang A',
-     'type' => 'branch',
-     'is_active' => true,
- ])->assertCreated()
+            'code' => 'WH-A',
+            'name' => 'Gudang A',
+            'type' => 'branch',
+            'is_active' => true,
+        ])->assertCreated()
             ->assertJsonPath('data.code', 'WH-A');
 
         $warehouseId = $response->json('data.id');

--- a/tests/Feature/Api/PosApiCashValidationTest.php
+++ b/tests/Feature/Api/PosApiCashValidationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class PosApiCashValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $cashier;
+
+    private Warehouse $warehouse;
+
+    private Product $product;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cashier = User::factory()->create();
+        $this->warehouse = Warehouse::create([
+            'code' => 'WH-1',
+            'name' => 'Gudang Utama',
+            'status' => 'active',
+        ]);
+        $category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => '',
+            'description' => '',
+        ]);
+        $this->product = Product::create([
+            'title' => 'Produk Kasir',
+            'barcode' => 'CASH-'.uniqid(),
+            'sku' => 'SKU-CASH-'.uniqid(),
+            'image' => '',
+            'description' => '',
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 50,
+            'category_id' => $category->id,
+            'tax_type' => 'exclusive',
+            'tax_rate' => 0,
+            'min_stock' => 0,
+            'max_stock' => 100,
+            'is_composite' => false,
+        ]);
+        $this->product->warehouses()->attach($this->warehouse->id, ['stock' => 50]);
+
+        Sanctum::actingAs($this->cashier, ['*']);
+
+        app(CashierShiftService::class)->openShift(
+            cashier: $this->cashier,
+            actor: $this->cashier,
+            openingCash: 100000,
+            notes: null,
+            warehouseId: $this->warehouse->id
+        );
+    }
+
+    private function addToCart(): void
+    {
+        $this->postJson('/api/v1/pos/cart', [
+            'product_id' => $this->product->id,
+            'qty' => 1,
+        ])->assertOk();
+    }
+
+    private function pivotStock(): int
+    {
+        return (int) $this->warehouse->products()->where('product_id', $this->product->id)->first()->pivot->stock;
+    }
+
+    public function test_cash_zero_is_rejected(): void
+    {
+        $this->addToCart();
+
+        $this->postJson('/api/v1/pos/checkout', [
+            'payment_method' => 'cash',
+            'cash' => 0,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('cash');
+
+        $this->assertEquals(0, Transaction::count());
+        $this->assertEquals(50, $this->pivotStock());
+        $this->assertEquals(1, Cart::where('product_id', $this->product->id)->count());
+    }
+
+    public function test_cash_below_total_is_rejected(): void
+    {
+        $this->addToCart();
+
+        $this->postJson('/api/v1/pos/checkout', [
+            'payment_method' => 'cash',
+            'cash' => 9999,
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors('cash');
+
+        $this->assertEquals(0, Transaction::count());
+        $this->assertEquals(50, $this->pivotStock());
+    }
+
+    public function test_cash_equal_total_succeeds(): void
+    {
+        $this->addToCart();
+
+        $this->postJson('/api/v1/pos/checkout', [
+            'payment_method' => 'cash',
+            'cash' => 10000,
+        ])->assertCreated()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.payment_status', 'paid')
+            ->assertJsonPath('data.change', 0);
+
+        $this->assertEquals(49, $this->pivotStock());
+    }
+
+    public function test_cash_above_total_succeeds_with_change(): void
+    {
+        $this->addToCart();
+
+        $this->postJson('/api/v1/pos/checkout', [
+            'payment_method' => 'cash',
+            'cash' => 50000,
+        ])->assertCreated()
+            ->assertJsonPath('data.change', 40000);
+
+        $this->assertEquals(49, $this->pivotStock());
+    }
+}

--- a/tests/Feature/Api/ProductApiTest.php
+++ b/tests/Feature/Api/ProductApiTest.php
@@ -14,6 +14,7 @@ class ProductApiTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+
     private Category $category;
 
     protected function setUp(): void
@@ -55,7 +56,7 @@ class ProductApiTest extends TestCase
 
     public function test_products_index_paginates(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         for ($i = 1; $i <= 25; $i++) {
             $this->makeProduct('Produk '.$i, 'BC-'.$i);
@@ -73,7 +74,7 @@ class ProductApiTest extends TestCase
 
     public function test_products_search_filters(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $this->makeProduct('Minyak Goreng', 'BC-MG');
         $this->makeProduct('Gula Pasir', 'BC-GP');
@@ -87,7 +88,7 @@ class ProductApiTest extends TestCase
 
     public function test_products_store_creates(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $response = $this->postJson('/api/v1/products', [
             'title' => 'Produk Baru',
@@ -106,7 +107,7 @@ class ProductApiTest extends TestCase
 
     public function test_products_store_validation_duplicate_barcode(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $this->makeProduct('Produk Ada', 'DUP-001');
 
@@ -121,7 +122,7 @@ class ProductApiTest extends TestCase
 
     public function test_products_update_partial(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $product = $this->makeProduct('Produk Update', 'UPD-001');
 
@@ -132,14 +133,14 @@ class ProductApiTest extends TestCase
 
     public function test_products_show_404_for_missing(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $this->getJson('/api/v1/products/99999')->assertStatus(404);
     }
 
     public function test_products_destroy_returns_204(): void
     {
-        Sanctum::actingAs($this->user);
+        Sanctum::actingAs($this->user, ['*']);
 
         $product = $this->makeProduct('Produk Hapus', 'DEL-001');
 

--- a/tests/Feature/AuditLogs/AuditLogTest.php
+++ b/tests/Feature/AuditLogs/AuditLogTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\AuditLogs;
 
 use App\Models\AuditLog;
+use App\Models\BankAccount;
 use App\Models\CashierShift;
 use App\Models\Category;
 use App\Models\Customer;
@@ -269,6 +270,14 @@ class AuditLogTest extends TestCase
             'module' => 'stock',
         ]);
 
+        $bankAccount = BankAccount::create([
+            'bank_name' => 'BCA',
+            'account_number' => '1234567890',
+            'account_name' => 'Toko',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
         $transaction = Transaction::create([
             'cashier_id' => $user->id,
             'customer_id' => null,
@@ -280,6 +289,7 @@ class AuditLogTest extends TestCase
             'grand_total' => 50000,
             'payment_method' => 'bank_transfer',
             'payment_status' => 'pending',
+            'bank_account_id' => $bankAccount->id,
         ]);
 
         $this->withSession($this->recentlyConfirmedSession())->actingAs($user)

--- a/tests/Feature/DineIn/DineOrderStatusTest.php
+++ b/tests/Feature/DineIn/DineOrderStatusTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\DineIn;
+
+use App\Models\Category;
+use App\Models\DineOrder;
+use App\Models\DiningTable;
+use App\Models\Product;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DineOrderStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Dine',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test dine',
+        ]);
+
+        $this->table = DiningTable::create([
+            'name' => 'Meja 1',
+            'is_active' => true,
+            'capacity' => 4,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $stock = 10): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Menu Dine '.self::$seq,
+            'sku' => 'SKU-DINEST-'.self::$seq,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => $stock,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-DINEST-'.self::$seq,
+            'description' => 'Menu untuk test dine status',
+            'tax_rate' => 0,
+            'category_id' => $this->category->id,
+        ]);
+
+        $product->warehouses()->attach($this->warehouse->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function createOrder(?callable $mutate = null): DineOrder
+    {
+        $product = $this->createProduct();
+
+        $order = DineOrder::create([
+            'dine_table_id' => $this->table->id,
+            'status' => DineOrder::STATUS_SUBMITTED,
+            'payment_option' => DineOrder::PAY_AT_COUNTER,
+            'subtotal' => 10000,
+            'item_count' => 1,
+            'access_token' => Str::uuid()->toString(),
+        ]);
+
+        $order->items()->create([
+            'product_id' => $product->id,
+            'qty' => 1,
+            'price' => 10000,
+        ]);
+
+        if ($mutate) {
+            $mutate($order);
+        }
+
+        return $order->fresh();
+    }
+
+    public function test_status_check_returns_minimal_order_fields(): void
+    {
+        $order = $this->createOrder();
+
+        $response = $this->getJson(route('dine-order.status-check', $order->access_token));
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'order' => [
+                'id', 'status', 'payment_option', 'payment_status', 'subtotal', 'item_count', 'updated_at',
+            ],
+        ]);
+
+        $payload = $response->json('order');
+        $this->assertArrayNotHasKey('items', $payload);
+        $this->assertArrayNotHasKey('notes', $payload);
+        $this->assertSame('submitted', $payload['status']);
+    }
+
+    public function test_status_check_unknown_token_returns_404(): void
+    {
+        $this->getJson(route('dine-order.status-check', Str::uuid()->toString()))
+            ->assertNotFound();
+    }
+
+    public function test_status_check_stale_order_returns_410(): void
+    {
+        $order = $this->createOrder();
+
+        DineOrder::whereKey($order->id)->update(['updated_at' => now()->subHours(25)]);
+
+        $this->getJson(route('dine-order.status-check', $order->access_token))
+            ->assertStatus(410);
+    }
+
+    public function test_status_page_still_renders_full_order_with_items(): void
+    {
+        $order = $this->createOrder();
+
+        $response = $this->get(route('dine-order.status', $order->access_token));
+
+        $response->assertOk();
+        $response->assertSee('Menu Dine');
+    }
+}

--- a/tests/Feature/DineIn/DineOrderTest.php
+++ b/tests/Feature/DineIn/DineOrderTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Tests\Feature\DineIn;
+
+use App\Models\Category;
+use App\Models\DineOrder;
+use App\Models\DiningTable;
+use App\Models\Product;
+use App\Models\ProductWarehouse;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DineOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $this->table = DiningTable::create([
+            'name' => 'Meja 1',
+            'is_active' => true,
+            'capacity' => 4,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $stock, bool $isComposite = false): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Produk '.self::$seq,
+            'sku' => 'SKU-DINE-'.self::$seq,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => $stock,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-DINE-'.self::$seq,
+            'description' => 'Deskripsi produk test',
+            'tax_rate' => 0,
+            'category_id' => $this->category->id,
+            'is_composite' => $isComposite,
+        ]);
+
+        $product->warehouses()->attach($this->warehouse->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function orderPayload(array $items, array $overrides = []): array
+    {
+        return array_merge([
+            'items' => $items,
+            'payment_option' => 'pay_at_counter',
+        ], $overrides);
+    }
+
+    public function test_store_rejects_pay_online(): void
+    {
+        $product = $this->createProduct(10);
+
+        $this->from(route('dine.menu', $this->table->token))
+            ->post(route('dine-order.store', $this->table->token), $this->orderPayload(
+                [['product_id' => $product->id, 'qty' => 1]],
+                ['payment_option' => 'pay_online']
+            ))
+            ->assertSessionHasErrors('payment_option');
+
+        $this->assertEquals(0, DineOrder::count());
+    }
+
+    public function test_store_pay_at_counter_succeeds(): void
+    {
+        $product = $this->createProduct(10);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $product->id, 'qty' => 2],
+        ]))->assertSessionHasNoErrors();
+
+        $order = DineOrder::firstOrFail();
+        $this->assertEquals('submitted', $order->status);
+        $this->assertEquals('pay_at_counter', $order->payment_option);
+        $this->assertEquals(20000, $order->subtotal);
+        $this->assertEquals(2, $order->item_count);
+        $this->assertDatabaseHas('dine_order_items', [
+            'dine_order_id' => $order->id,
+            'product_id' => $product->id,
+            'qty' => 2,
+            'price' => 10000,
+        ]);
+    }
+
+    public function test_store_rejects_qty_exceeding_global_stock(): void
+    {
+        $product = $this->createProduct(3);
+
+        $this->from(route('dine.menu', $this->table->token))
+            ->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+                ['product_id' => $product->id, 'qty' => 5],
+            ]))
+            ->assertSessionHas('error');
+
+        $this->assertEquals(0, DineOrder::count());
+    }
+
+    public function test_accept_decrements_warehouse_and_global_stock(): void
+    {
+        $product = $this->createProduct(50);
+        $this->actingAs($this->cashier);
+        app(CashierShiftService::class)->openShift($this->cashier, $this->cashier, 0, null, $this->warehouse->id);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $product->id, 'qty' => 3],
+        ]));
+
+        $order = DineOrder::firstOrFail();
+        $this->actingAs($this->cashier);
+        $this->post(route('dine-orders.accept', $order))->assertSessionHasNoErrors();
+
+        $product = $product->fresh();
+        $this->assertEquals(47, $product->stock);
+
+        $pivot = ProductWarehouse::where('product_id', $product->id)
+            ->where('warehouse_id', $this->warehouse->id)
+            ->first();
+        $this->assertEquals(47, $pivot->stock);
+        $this->assertEquals('accepted', $order->fresh()->status);
+    }
+
+    public function test_accept_rejects_insufficient_stock_atomically(): void
+    {
+        $product = $this->createProduct(50);
+        $this->actingAs($this->cashier);
+        app(CashierShiftService::class)->openShift($this->cashier, $this->cashier, 0, null, $this->warehouse->id);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $product->id, 'qty' => 5],
+        ]));
+
+        $order = DineOrder::firstOrFail();
+
+        // stock drops below ordered qty after the order was submitted
+        $this->warehouse->products()->updateExistingPivot($product->id, ['stock' => 2]);
+        $product->update(['stock' => 2]);
+
+        $this->actingAs($this->cashier);
+        $this->from(route('dine-orders.index'))
+            ->post(route('dine-orders.accept', $order))
+            ->assertSessionHasErrors('stock');
+
+        $this->assertEquals('submitted', $order->fresh()->status);
+        $this->assertEquals(2, $product->fresh()->stock);
+
+        $pivot = ProductWarehouse::where('product_id', $product->id)
+            ->where('warehouse_id', $this->warehouse->id)
+            ->first();
+        $this->assertEquals(2, $pivot->stock);
+    }
+
+    public function test_accept_without_open_shift_rejected(): void
+    {
+        $product = $this->createProduct(50);
+        $this->actingAs($this->cashier);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $product->id, 'qty' => 2],
+        ]));
+
+        $order = DineOrder::firstOrFail();
+
+        $this->actingAs($this->cashier);
+        $this->from(route('dine-orders.index'))
+            ->post(route('dine-orders.accept', $order))
+            ->assertSessionHasErrors('shift');
+
+        $this->assertEquals('submitted', $order->fresh()->status);
+        $this->assertEquals(50, $product->fresh()->stock);
+    }
+
+    public function test_status_page_renders_order(): void
+    {
+        $product = $this->createProduct(10);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $product->id, 'qty' => 1],
+        ]));
+
+        $order = DineOrder::firstOrFail();
+
+        $this->get(route('dine-order.status', $order->access_token))
+            ->assertOk()
+            ->assertSee('Produk '.self::$seq);
+    }
+
+    public function test_store_maps_product_pricing_for_composite(): void
+    {
+        $componentA = $this->createProduct(10);
+        $componentB = $this->createProduct(10);
+        $composite = $this->createProduct(0, true);
+        $composite->components()->attach([
+            $componentA->id => ['qty' => 1],
+            $componentB->id => ['qty' => 2],
+        ]);
+
+        $this->post(route('dine-order.store', $this->table->token), $this->orderPayload([
+            ['product_id' => $composite->id, 'qty' => 1],
+        ]))->assertSessionHasNoErrors();
+
+        $order = DineOrder::firstOrFail();
+        $this->assertEquals(30000, $order->subtotal);
+    }
+}

--- a/tests/Feature/Documents/PublicInvoiceAuthorizationTest.php
+++ b/tests/Feature/Documents/PublicInvoiceAuthorizationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Documents;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicInvoiceAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $cashier = User::where('email', 'cashier@gmail.com')->first();
+        $cashier->markEmailAsVerified();
+
+        $this->actingAs($cashier);
+
+        $category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $product = Product::create([
+            'title' => 'Produk Test',
+            'sku' => 'SKU-INV-'.uniqid(),
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-INV-'.uniqid(),
+            'description' => 'Deskripsi produk test',
+            'tax_rate' => 0,
+            'category_id' => $category->id,
+        ]);
+        $warehouse->products()->attach($product->id, ['stock' => 100]);
+
+        app(CashierShiftService::class)->openShift($cashier, $cashier, 0, null, $warehouse->id);
+
+        $this->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'sell_price' => 10000,
+            'qty' => 1,
+        ]);
+
+        $this->post(route('transactions.store'), [
+            'payment_method' => 'cash',
+            'cash' => 10000,
+        ])->assertSessionHasNoErrors();
+
+        $this->transaction = Transaction::latest('id')->first();
+        $this->assertNotNull($this->transaction->access_token);
+    }
+
+    public function test_public_invoice_requires_valid_access_token(): void
+    {
+        $this->get(route('transactions.public', [
+            'invoice' => $this->transaction->invoice,
+            'token' => $this->transaction->access_token,
+        ]))->assertOk();
+    }
+
+    public function test_public_invoice_rejects_missing_token(): void
+    {
+        $this->get(route('transactions.public', $this->transaction->invoice))
+            ->assertNotFound();
+    }
+
+    public function test_public_invoice_rejects_wrong_token(): void
+    {
+        $this->get(route('transactions.public', [
+            'invoice' => $this->transaction->invoice,
+            'token' => 'wrong-token',
+        ]))->assertNotFound();
+    }
+
+    public function test_public_invoice_rejects_unknown_invoice(): void
+    {
+        $this->get(route('transactions.public', [
+            'invoice' => 'INV-NOT-EXIST',
+            'token' => $this->transaction->access_token,
+        ]))->assertNotFound();
+    }
+}

--- a/tests/Feature/Finance/PaymentIntegrityTest.php
+++ b/tests/Feature/Finance/PaymentIntegrityTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature\Finance;
+
+use App\Models\Customer;
+use App\Models\Payable;
+use App\Models\PayablePayment;
+use App\Models\Receivable;
+use App\Models\ReceivablePayment;
+use App\Models\Supplier;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaymentIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+    }
+
+    private function makeCustomer(): Customer
+    {
+        return Customer::create([
+            'name' => 'Customer Tagihan',
+            'no_telp' => '628111000001',
+            'address' => 'Jl. Test',
+        ]);
+    }
+
+    private function makeSupplier(): Supplier
+    {
+        return Supplier::create([
+            'name' => 'Supplier Tagihan',
+            'phone' => '081234567890',
+            'email' => 'supplier@test.com',
+        ]);
+    }
+
+    private function makeReceivable(float $total = 100000): Receivable
+    {
+        return Receivable::create([
+            'customer_id' => $this->makeCustomer()->id,
+            'invoice' => 'RCV-'.uniqid(),
+            'total' => $total,
+            'paid' => 0,
+            'due_date' => now()->addDays(7),
+            'status' => 'unpaid',
+        ]);
+    }
+
+    private function makePayable(float $total = 100000): Payable
+    {
+        return Payable::create([
+            'supplier_id' => $this->makeSupplier()->id,
+            'document_number' => 'INV-'.uniqid(),
+            'total' => $total,
+            'paid' => 0,
+            'due_date' => now()->addDays(7),
+            'status' => 'unpaid',
+        ]);
+    }
+
+    private function payReceivablePayload(float $amount): array
+    {
+        return [
+            'amount' => $amount,
+            'paid_at' => now()->toDateString(),
+            'method' => 'cash',
+            'note' => 'Bayar piutang',
+        ];
+    }
+
+    private function payPayablePayload(float $amount): array
+    {
+        return [
+            'amount' => $amount,
+            'paid_at' => now()->toDateString(),
+            'method' => 'cash',
+            'note' => 'Bayar hutang',
+        ];
+    }
+
+    public function test_receivable_overpay_rejected(): void
+    {
+        $receivable = $this->makeReceivable(100000);
+
+        $this->from(route('receivables.show', $receivable))
+            ->post(route('receivables.pay', $receivable), $this->payReceivablePayload(150000))
+            ->assertSessionHasErrors('amount');
+
+        $this->assertEquals(0, ReceivablePayment::count());
+        $this->assertEquals(0, $receivable->fresh()->paid);
+        $this->assertEquals('unpaid', $receivable->fresh()->status);
+    }
+
+    public function test_receivable_exact_pay_marks_paid(): void
+    {
+        $receivable = $this->makeReceivable(100000);
+
+        $this->post(route('receivables.pay', $receivable), $this->payReceivablePayload(100000))
+            ->assertRedirect(route('receivables.show', $receivable))
+            ->assertSessionHas('success');
+
+        $receivable = $receivable->fresh();
+        $this->assertEquals(100000, $receivable->paid);
+        $this->assertEquals('paid', $receivable->status);
+        $this->assertDatabaseHas('receivable_payments', [
+            'receivable_id' => $receivable->id,
+            'amount' => 100000,
+        ]);
+    }
+
+    public function test_receivable_partial_pay_sets_partial_status(): void
+    {
+        $receivable = $this->makeReceivable(100000);
+
+        $this->post(route('receivables.pay', $receivable), $this->payReceivablePayload(40000))
+            ->assertSessionHas('success');
+
+        $receivable = $receivable->fresh();
+        $this->assertEquals(40000, $receivable->paid);
+        $this->assertEquals('partial', $receivable->status);
+    }
+
+    public function test_receivable_second_pay_cannot_exceed_remaining(): void
+    {
+        $receivable = $this->makeReceivable(100000);
+
+        $this->post(route('receivables.pay', $receivable), $this->payReceivablePayload(70000))
+            ->assertSessionHas('success');
+
+        $this->from(route('receivables.show', $receivable))
+            ->post(route('receivables.pay', $receivable), $this->payReceivablePayload(50000))
+            ->assertSessionHasErrors('amount');
+
+        $receivable = $receivable->fresh();
+        $this->assertEquals(70000, $receivable->paid);
+        $this->assertEquals('partial', $receivable->status);
+        $this->assertEquals(1, ReceivablePayment::count());
+    }
+
+    public function test_payable_overpay_rejected(): void
+    {
+        $payable = $this->makePayable(100000);
+
+        $this->from(route('payables.show', $payable))
+            ->post(route('payables.pay', $payable), $this->payPayablePayload(120000))
+            ->assertSessionHasErrors('amount');
+
+        $this->assertEquals(0, PayablePayment::count());
+        $this->assertEquals(0, $payable->fresh()->paid);
+        $this->assertEquals('unpaid', $payable->fresh()->status);
+    }
+
+    public function test_payable_exact_pay_marks_paid(): void
+    {
+        $payable = $this->makePayable(100000);
+
+        $this->post(route('payables.pay', $payable), $this->payPayablePayload(100000))
+            ->assertRedirect(route('payables.show', $payable))
+            ->assertSessionHas('success');
+
+        $payable = $payable->fresh();
+        $this->assertEquals(100000, $payable->paid);
+        $this->assertEquals('paid', $payable->status);
+        $this->assertDatabaseHas('payable_payments', [
+            'payable_id' => $payable->id,
+            'amount' => 100000,
+        ]);
+    }
+
+    public function test_payable_partial_pay_sets_partial_status(): void
+    {
+        $payable = $this->makePayable(100000);
+
+        $this->post(route('payables.pay', $payable), $this->payPayablePayload(25000))
+            ->assertSessionHas('success');
+
+        $payable = $payable->fresh();
+        $this->assertEquals(25000, $payable->paid);
+        $this->assertEquals('partial', $payable->status);
+    }
+
+    public function test_payable_second_pay_cannot_exceed_remaining(): void
+    {
+        $payable = $this->makePayable(100000);
+
+        $this->post(route('payables.pay', $payable), $this->payPayablePayload(80000))
+            ->assertSessionHas('success');
+
+        $this->from(route('payables.show', $payable))
+            ->post(route('payables.pay', $payable), $this->payPayablePayload(30000))
+            ->assertSessionHasErrors('amount');
+
+        $payable = $payable->fresh();
+        $this->assertEquals(80000, $payable->paid);
+        $this->assertEquals('partial', $payable->status);
+        $this->assertEquals(1, PayablePayment::count());
+    }
+}

--- a/tests/Feature/Inventory/InventoryReconcileCommandTest.php
+++ b/tests/Feature/Inventory/InventoryReconcileCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Inventory;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventoryReconcileCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $globalStock, int $pivotStock): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Produk '.self::$seq,
+            'sku' => 'SKU-REC-'.self::$seq,
+            'barcode' => 'BC-REC-'.self::$seq,
+            'image' => 'products/test.jpg',
+            'description' => 'Deskripsi produk test',
+            'category_id' => $this->category->id,
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => $globalStock,
+            'tax_rate' => 0,
+        ]);
+
+        $product->warehouses()->attach($this->warehouse->id, ['stock' => $pivotStock]);
+
+        return $product;
+    }
+
+    public function test_report_identifies_mismatch_between_global_and_pivot_stock(): void
+    {
+        $this->createProduct(100, 60);
+
+        $this->artisan('inventory:reconcile')
+            ->expectsOutputToContain('products.stock differs')
+            ->expectsOutputToContain('100')
+            ->assertSuccessful();
+
+        // report mode is read-only
+        $this->assertEquals(100, Product::latest('id')->first()->stock);
+    }
+
+    public function test_report_is_silent_when_consistent(): void
+    {
+        $this->createProduct(60, 60);
+
+        $this->artisan('inventory:reconcile')
+            ->expectsOutputToContain('Inventory is consistent')
+            ->assertSuccessful();
+    }
+
+    public function test_fix_aligns_global_stock_to_pivot_total(): void
+    {
+        $this->createProduct(100, 60);
+
+        $this->artisan('inventory:reconcile', ['--fix' => true])
+            ->assertSuccessful();
+
+        $this->assertEquals(60, Product::latest('id')->first()->stock);
+    }
+}

--- a/tests/Feature/Inventory/StockTransferIntegrityTest.php
+++ b/tests/Feature/Inventory/StockTransferIntegrityTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Feature\Inventory;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductWarehouse;
+use App\Models\StockMutation;
+use App\Models\StockTransfer;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\StockTransferService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StockTransferIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected Warehouse $source;
+
+    protected Warehouse $destination;
+
+    protected Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+
+        $this->source = Warehouse::create([
+            'code' => 'GDG-A',
+            'name' => 'Gudang A',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->destination = Warehouse::create([
+            'code' => 'GDG-B',
+            'name' => 'Gudang B',
+            'type' => 'branch',
+            'is_active' => true,
+            'sort_order' => 1,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Transfer',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test transfer',
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $sourceStock, ?int $destStock = null): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Produk Transfer '.self::$seq,
+            'sku' => 'SKU-ST-'.self::$seq,
+            'buy_price' => 10000,
+            'sell_price' => 15000,
+            'stock' => $sourceStock,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-ST-'.self::$seq,
+            'description' => 'Deskripsi produk transfer',
+            'tax_rate' => 0,
+            'category_id' => $this->category->id,
+        ]);
+
+        $product->warehouses()->attach($this->source->id, ['stock' => $sourceStock]);
+
+        if ($destStock !== null) {
+            $product->warehouses()->attach($this->destination->id, ['stock' => $destStock]);
+        }
+
+        return $product;
+    }
+
+    private function createDraft(Product $product, int $qty): StockTransfer
+    {
+        return app(StockTransferService::class)->createDraft(
+            data: [
+                'source_warehouse_id' => $this->source->id,
+                'destination_warehouse_id' => $this->destination->id,
+            ],
+            items: [[
+                'product_id' => $product->id,
+                'qty' => $qty,
+            ]],
+            userId: $this->admin->id
+        );
+    }
+
+    private function pivotStock(int $productId, int $warehouseId): int
+    {
+        $pw = ProductWarehouse::where('product_id', $productId)
+            ->where('warehouse_id', $warehouseId)
+            ->first();
+
+        return $pw ? (int) $pw->stock : 0;
+    }
+
+    public function test_send_moves_stock_to_in_transit_and_records_out_mutation(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+
+        $this->post(route('stock-transfers.send', $transfer))
+            ->assertSessionHas('success');
+
+        $this->assertEquals('in_transit', $transfer->fresh()->status);
+        $this->assertEquals(40, $product->fresh()->stock);
+        $this->assertEquals(40, $this->pivotStock($product->id, $this->source->id));
+
+        $mutation = StockMutation::where('reference_type', 'stock_transfer')
+            ->where('reference_id', $transfer->id)
+            ->where('mutation_type', 'out')
+            ->first();
+        $this->assertNotNull($mutation);
+        $this->assertEquals(50, $mutation->stock_before);
+        $this->assertEquals(40, $mutation->stock_after);
+    }
+
+    public function test_send_rejects_draft_that_is_not_draft_anymore(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+        $transfer->update(['status' => 'in_transit']);
+
+        $this->from(route('stock-transfers.index'))
+            ->post(route('stock-transfers.send', $transfer->fresh()))
+            ->assertSessionHasErrors('transfer');
+
+        $this->assertEquals(50, $product->fresh()->stock);
+    }
+
+    public function test_send_rejects_insufficient_source_stock(): void
+    {
+        $product = $this->createProduct(5);
+        $transfer = $this->createDraft($product, 10);
+
+        $this->from(route('stock-transfers.index'))
+            ->post(route('stock-transfers.send', $transfer))
+            ->assertSessionHasErrors('transfer');
+
+        $this->assertEquals('draft', $transfer->fresh()->status);
+        $this->assertEquals(5, $product->fresh()->stock);
+        $this->assertEquals(5, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(0, $this->pivotStock($product->id, $this->destination->id));
+    }
+
+    public function test_receive_increments_destination_and_completes(): void
+    {
+        $product = $this->createProduct(50, 0);
+        $transfer = $this->createDraft($product, 10);
+        app(StockTransferService::class)->send($transfer, $this->admin->id);
+
+        $this->post(route('stock-transfers.receive', $transfer->fresh()))
+            ->assertSessionHas('success');
+
+        $this->assertEquals('completed', $transfer->fresh()->status);
+        $this->assertNotNull($transfer->fresh()->completed_at);
+        $this->assertEquals(50, $product->fresh()->stock);
+        $this->assertEquals(40, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(10, $this->pivotStock($product->id, $this->destination->id));
+
+        $mutation = StockMutation::where('reference_type', 'stock_transfer')
+            ->where('reference_id', $transfer->id)
+            ->where('mutation_type', 'in')
+            ->first();
+        $this->assertNotNull($mutation);
+        $this->assertEquals(40, $mutation->stock_before);
+        $this->assertEquals(50, $mutation->stock_after);
+    }
+
+    public function test_double_receive_is_rejected(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+        $service = app(StockTransferService::class);
+        $service->send($transfer, $this->admin->id);
+        $service->receive($transfer->fresh(), $this->admin->id);
+
+        $this->from(route('stock-transfers.index'))
+            ->post(route('stock-transfers.receive', $transfer->fresh()))
+            ->assertSessionHasErrors('transfer');
+
+        $this->assertEquals('completed', $transfer->fresh()->status);
+        $this->assertEquals(50, $product->fresh()->stock);
+        $this->assertEquals(40, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(10, $this->pivotStock($product->id, $this->destination->id));
+    }
+
+    public function test_cancel_in_transit_returns_stock_to_source(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+        $service = app(StockTransferService::class);
+        $service->send($transfer, $this->admin->id);
+
+        $this->post(route('stock-transfers.cancel', $transfer->fresh()))
+            ->assertSessionHas('success');
+
+        $this->assertEquals('cancelled', $transfer->fresh()->status);
+        $this->assertEquals(50, $product->fresh()->stock);
+        $this->assertEquals(50, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(0, $this->pivotStock($product->id, $this->destination->id));
+    }
+
+    public function test_cancel_draft_does_not_touch_stock(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+
+        $this->post(route('stock-transfers.cancel', $transfer))
+            ->assertSessionHas('success');
+
+        $this->assertEquals('cancelled', $transfer->fresh()->status);
+        $this->assertEquals(50, $product->fresh()->stock);
+        $this->assertEquals(50, $this->pivotStock($product->id, $this->source->id));
+    }
+
+    public function test_cancel_completed_transfer_is_rejected(): void
+    {
+        $product = $this->createProduct(50);
+        $transfer = $this->createDraft($product, 10);
+        $service = app(StockTransferService::class);
+        $service->send($transfer, $this->admin->id);
+        $service->receive($transfer->fresh(), $this->admin->id);
+
+        $this->from(route('stock-transfers.index'))
+            ->post(route('stock-transfers.cancel', $transfer->fresh()))
+            ->assertSessionHasErrors('transfer');
+
+        $this->assertEquals('completed', $transfer->fresh()->status);
+        $this->assertEquals(50, $product->fresh()->stock);
+        $this->assertEquals(40, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(10, $this->pivotStock($product->id, $this->destination->id));
+    }
+
+    public function test_receiving_creates_destination_pivot_when_missing(): void
+    {
+        $product = $this->createProduct(50); // no destination pivot row
+        $transfer = $this->createDraft($product, 10);
+        $service = app(StockTransferService::class);
+        $service->send($transfer, $this->admin->id);
+
+        $service->receive($transfer->fresh(), $this->admin->id);
+
+        $this->assertEquals(10, $this->pivotStock($product->id, $this->destination->id));
+        $this->assertEquals(40, $this->pivotStock($product->id, $this->source->id));
+        $this->assertEquals(50, $product->fresh()->stock);
+    }
+}

--- a/tests/Feature/Loyalty/CustomerVoucherConcurrencyTest.php
+++ b/tests/Feature/Loyalty/CustomerVoucherConcurrencyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Loyalty;
+
+use App\Models\Customer;
+use App\Models\CustomerVoucher;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\LoyaltyService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class CustomerVoucherConcurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+    }
+
+    private function createCustomer(string $code): Customer
+    {
+        return Customer::create([
+            'name' => 'Member '.$code,
+            'no_telp' => '628777000'.random_int(100, 999),
+            'address' => 'Jl. Voucher',
+            'is_loyalty_member' => true,
+            'member_code' => 'MEM-'.$code,
+            'loyalty_points' => 0,
+        ]);
+    }
+
+    private function createVoucher(Customer $customer, string $code): CustomerVoucher
+    {
+        return CustomerVoucher::create([
+            'customer_id' => $customer->id,
+            'code' => $code,
+            'name' => 'Voucher '.$code,
+            'discount_type' => CustomerVoucher::TYPE_FIXED_AMOUNT,
+            'discount_value' => 10000,
+            'minimum_order' => 50000,
+            'is_active' => true,
+        ]);
+    }
+
+    private function makeTransaction(Customer $customer, string $voucherCode): Transaction
+    {
+        return Transaction::create([
+            'cashier_id' => User::factory()->create()->id,
+            'invoice' => 'INV-'.Str::upper(Str::random(8)),
+            'customer_id' => $customer->id,
+            'customer_voucher_code' => $voucherCode,
+            'customer_voucher_discount' => 10000,
+            'discount' => 0,
+            'grand_total' => 50000,
+            'cash' => 50000,
+            'change' => 0,
+            'payment_method' => 'cash',
+            'payment_status' => 'paid',
+            'tax_rate' => 0,
+            'tax_total' => 0,
+        ]);
+    }
+
+    public function test_finalize_claims_voucher_and_marks_it_used(): void
+    {
+        $customer = $this->createCustomer('ONE');
+        $voucher = $this->createVoucher($customer, 'VCR-CLAIM');
+        $transaction = $this->makeTransaction($customer, 'VCR-CLAIM');
+
+        app(LoyaltyService::class)->finalizeTransaction($transaction, $customer, ['voucher' => $voucher]);
+
+        $voucher->refresh();
+        $this->assertTrue($voucher->is_used);
+        $this->assertSame($transaction->id, $voucher->used_transaction_id);
+    }
+
+    public function test_second_finalize_with_same_voucher_throws_atomically(): void
+    {
+        $customer = $this->createCustomer('TWO');
+        $voucher = $this->createVoucher($customer, 'VCR-RACE');
+        $transaction = $this->makeTransaction($customer, 'VCR-RACE');
+
+        $service = app(LoyaltyService::class);
+
+        // First concurrent checkout claims the voucher
+        $service->finalizeTransaction($transaction, $customer, ['voucher' => $voucher]);
+
+        $voucher->refresh();
+        $this->assertTrue($voucher->is_used);
+        $this->assertSame($transaction->id, $voucher->used_transaction_id);
+
+        // Second concurrent finalize of the same single-use voucher must fail atomically
+        try {
+            $service->finalizeTransaction($transaction, $customer, ['voucher' => $voucher]);
+            $this->fail('Expected ValidationException for double voucher redemption.');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('voucher_code', $e->errors());
+        }
+
+        // No duplicate claim recorded
+        $this->assertSame(1, CustomerVoucher::where('code', 'VCR-RACE')->where('is_used', true)->count());
+    }
+}

--- a/tests/Feature/Products/BatchAllocationTest.php
+++ b/tests/Feature/Products/BatchAllocationTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\Products;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductBatch;
+use App\Models\TransactionDetail;
+use App\Models\TransactionDetailBatchAllocation;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BatchAllocationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $cashier;
+
+    private Warehouse $pusat;
+
+    private Category $category;
+
+    private CashierShiftService $cashierShiftService;
+
+    private static int $seq = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([
+            PermissionSeeder::class,
+            RoleSeeder::class,
+            UserSeeder::class,
+        ]);
+
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+
+        $this->cashierShiftService = app(CashierShiftService::class);
+
+        $this->pusat = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Test Category',
+            'image' => 'test.png',
+            'description' => 'desc',
+        ]);
+    }
+
+    private function createProduct(int $stock = 0): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Batched Product '.self::$seq,
+            'sku' => 'SKU-BATCHALLOC-'.self::$seq,
+            'barcode' => 'BC-BATCHALLOC-'.self::$seq,
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 1000,
+            'sell_price' => 2000,
+            'stock' => $stock,
+            'tax_rate' => 0,
+        ]);
+
+        $product->warehouses()->attach($this->pusat->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function createBatch(Product $product, string $batchNumber, string $expiredAt, int $stock): ProductBatch
+    {
+        return ProductBatch::create([
+            'product_id' => $product->id,
+            'warehouse_id' => $this->pusat->id,
+            'batch_number' => $batchNumber,
+            'expired_at' => $expiredAt,
+            'received_at' => '2026-01-01',
+            'stock' => $stock,
+        ]);
+    }
+
+    public function test_checkout_records_every_batch_allocation(): void
+    {
+        $product = $this->createProduct(30);
+        $batchA = $this->createBatch($product, 'BATCH-A', now()->addDays(10)->toDateString(), 5);
+        $batchB = $this->createBatch($product, 'BATCH-B', now()->addDays(60)->toDateString(), 20);
+
+        $this->cashierShiftService->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'sell_price' => $product->sell_price,
+                'qty' => 8,
+            ])
+            ->assertRedirect();
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 100000])
+            ->assertRedirect();
+
+        $detail = TransactionDetail::latest('id')->first();
+        // legacy first-batch column points at the earliest-expiring batch
+        $this->assertEquals($batchA->id, $detail->product_batch_id);
+
+        $allocations = TransactionDetailBatchAllocation::where('transaction_detail_id', $detail->id)
+            ->orderBy('product_batch_id')
+            ->get();
+        $this->assertCount(2, $allocations);
+        $this->assertEquals($batchA->id, $allocations->first()->product_batch_id);
+        $this->assertEquals(5, $allocations->first()->qty);
+        $this->assertEquals($batchB->id, $allocations->last()->product_batch_id);
+        $this->assertEquals(3, $allocations->last()->qty);
+
+        $this->assertEquals(0, $batchA->fresh()->stock);
+        $this->assertEquals(17, $batchB->fresh()->stock);
+    }
+
+    public function test_checkout_without_batches_creates_no_allocations(): void
+    {
+        $product = $this->createProduct(10);
+
+        $this->cashierShiftService->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'sell_price' => $product->sell_price,
+                'qty' => 2,
+            ])
+            ->assertRedirect();
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertRedirect();
+
+        $detail = TransactionDetail::latest('id')->first();
+        $this->assertNull($detail->product_batch_id);
+        $this->assertEquals(0, TransactionDetailBatchAllocation::where('transaction_detail_id', $detail->id)->count());
+    }
+}

--- a/tests/Feature/Purchasing/GoodsReceivingTest.php
+++ b/tests/Feature/Purchasing/GoodsReceivingTest.php
@@ -214,4 +214,46 @@ class GoodsReceivingTest extends TestCase
         $this->assertEquals('completed', $order->fresh()->status);
         $this->assertNotNull($order->fresh()->completed_at);
     }
+
+    public function test_receiving_rejects_duplicate_po_item_in_one_payload(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+        $poItemId = $order->items->first()->id;
+
+        $payload = [
+            'purchase_order_id' => $order->id,
+            'items' => [
+                ['purchase_order_item_id' => $poItemId, 'qty_received' => 4],
+                ['purchase_order_item_id' => $poItemId, 'qty_received' => 4],
+            ],
+        ];
+
+        $response = $this->post(route('goods-receivings.store'), $payload);
+
+        $response->assertSessionHas('error');
+        $this->assertEquals(0, GoodsReceiving::count());
+        $this->assertEquals(100, $product->fresh()->stock);
+        $this->assertEquals(0, $order->items->first()->fresh()->qty_received);
+    }
+
+    public function test_receiving_service_rejects_duplicate_items_each_within_outstanding(): void
+    {
+        $product = $this->createProduct(100);
+        $order = $this->createOrderedPo($product, 10, $this->warehouse->id);
+        $poItemId = $order->items->first()->id;
+
+        $this->post(route('goods-receivings.store'), [
+            'purchase_order_id' => $order->id,
+            'items' => [
+                ['purchase_order_item_id' => $poItemId, 'qty_received' => 6],
+                ['purchase_order_item_id' => $poItemId, 'qty_received' => 6],
+            ],
+        ])->assertSessionHas('error');
+
+        $this->assertEquals(0, GoodsReceiving::count());
+        $this->assertEquals(100, $product->fresh()->stock);
+        $this->assertEquals(0, $order->items->first()->fresh()->qty_received);
+        $this->assertEquals('ordered', $order->fresh()->status);
+    }
 }

--- a/tests/Feature/Transactions/CartAuthorizationTest.php
+++ b/tests/Feature/Transactions/CartAuthorizationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Models\Cart;
+use App\Models\CashierShift;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class CartAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->cashierA = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashierA->markEmailAsVerified();
+
+        $this->cashierB = User::factory()->create();
+        $this->cashierB->markEmailAsVerified();
+        Permission::findByName('transactions-access')->assignRole('cashier');
+        $this->cashierB->assignRole('cashier');
+
+        $this->actingAs($this->cashierA);
+    }
+
+    private function makeProduct(): Product
+    {
+        $category = Category::create([
+            'name' => 'Sembako',
+            'description' => 'Kategori pengujian',
+            'image' => 'category.png',
+        ]);
+
+        return Product::create([
+            'category_id' => $category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi produk uji.',
+            'buy_price' => 45000,
+            'sell_price' => 60000,
+            'stock' => 25,
+            'tax_rate' => 0,
+        ]);
+    }
+
+    private function openShiftFor(User $user): CashierShift
+    {
+        return CashierShift::create([
+            'user_id' => $user->id,
+            'opened_by' => $user->id,
+            'opened_at' => now(),
+            'opening_cash' => 100000,
+            'expected_cash' => 100000,
+            'status' => 'open',
+        ]);
+    }
+
+    public function test_cashier_cannot_delete_another_cashiers_cart(): void
+    {
+        $this->openShiftFor($this->cashierA);
+        $this->openShiftFor($this->cashierB);
+
+        $product = $this->makeProduct();
+        $otherCart = Cart::create([
+            'cashier_id' => $this->cashierB->id,
+            'product_id' => $product->id,
+            'qty' => 1,
+            'price' => $product->sell_price,
+        ]);
+
+        $this->actingAs($this->cashierA)
+            ->from(route('transactions.index'))
+            ->delete(route('transactions.destroyCart', $otherCart->id))
+            ->assertSessionHasErrors('message');
+
+        $this->assertDatabaseHas('carts', ['id' => $otherCart->id]);
+    }
+
+    public function test_cashier_can_delete_own_cart(): void
+    {
+        $this->openShiftFor($this->cashierA);
+
+        $product = $this->makeProduct();
+        $ownCart = Cart::create([
+            'cashier_id' => $this->cashierA->id,
+            'product_id' => $product->id,
+            'qty' => 1,
+            'price' => $product->sell_price,
+        ]);
+
+        $this->actingAs($this->cashierA)
+            ->from(route('transactions.index'))
+            ->delete(route('transactions.destroyCart', $ownCart->id))
+            ->assertSessionHasNoErrors();
+
+        $this->assertDatabaseMissing('carts', ['id' => $ownCart->id]);
+    }
+}

--- a/tests/Feature/Transactions/CartValidationTest.php
+++ b/tests/Feature/Transactions/CartValidationTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Unit;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CartValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+        $this->actingAs($this->cashier);
+
+        $this->category = Category::create([
+            'name' => 'Sembako',
+            'description' => 'Kategori pengujian',
+            'image' => 'category.png',
+        ]);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private function makeProduct(int $stock = 25): Product
+    {
+        $product = Product::create([
+            'category_id' => $this->category->id,
+            'image' => 'product.png',
+            'barcode' => 'BRCD-'.Str::upper(Str::random(10)),
+            'sku' => 'SKU-'.Str::upper(Str::random(10)),
+            'title' => 'Produk Uji',
+            'description' => 'Deskripsi produk uji.',
+            'buy_price' => 45000,
+            'sell_price' => 60000,
+            'stock' => $stock,
+            'tax_rate' => 0,
+        ]);
+
+        $this->warehouse->products()->attach($product->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function openShiftForCashier(): void
+    {
+        app(CashierShiftService::class)->openShift(
+            $this->cashier,
+            $this->cashier,
+            100000,
+            null,
+            $this->warehouse->id
+        );
+    }
+
+    public function test_add_to_cart_rejects_zero_qty(): void
+    {
+        $this->openShiftForCashier();
+        $product = $this->makeProduct();
+
+        $this->from(route('transactions.index'))
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'qty' => 0,
+            ])
+            ->assertSessionHasErrors('qty');
+
+        $this->assertDatabaseCount('carts', 0);
+    }
+
+    public function test_add_to_cart_rejects_negative_qty(): void
+    {
+        $this->openShiftForCashier();
+        $product = $this->makeProduct();
+
+        $this->from(route('transactions.index'))
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'qty' => -2,
+            ])
+            ->assertSessionHasErrors('qty');
+
+        $this->assertDatabaseCount('carts', 0);
+    }
+
+    public function test_add_to_cart_rejects_unit_not_belonging_to_product(): void
+    {
+        $this->openShiftForCashier();
+        $product = $this->makeProduct();
+
+        // BOX exists from migration seed but product only has default PCS base unit
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $product->units()->attach($pcs->id, [
+            'is_base' => true,
+            'conversion_factor' => 1,
+            'buy_price' => 45000,
+            'sell_price' => 60000,
+        ]);
+
+        $this->from(route('transactions.index'))
+            ->post(route('transactions.addToCart'), [
+                'product_id' => $product->id,
+                'qty' => 1,
+                'unit_id' => $box->id,
+            ])
+            ->assertSessionHas('error', 'Satuan tidak valid untuk produk ini.');
+
+        $this->assertDatabaseCount('carts', 0);
+    }
+
+    public function test_update_cart_checks_base_stock_for_box_unit(): void
+    {
+        $this->openShiftForCashier();
+        // Only 10 base units (PCS) available = less than 1 BOX (factor 12)
+        $product = $this->makeProduct(10);
+
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+        $product->units()->sync([
+            $pcs->id => ['is_base' => true, 'conversion_factor' => 1, 'buy_price' => 45000, 'sell_price' => 60000],
+            $box->id => ['is_base' => false, 'conversion_factor' => 12, 'buy_price' => 540000, 'sell_price' => 660000],
+        ]);
+
+        $cart = Cart::create([
+            'cashier_id' => $this->cashier->id,
+            'warehouse_id' => $this->warehouse->id,
+            'product_id' => $product->id,
+            'unit_id' => $box->id,
+            'conversion_factor' => 12,
+            'qty' => 1,
+            'price' => 660000,
+        ]);
+
+        $this->patch(route('transactions.updateCart', $cart->id), ['qty' => 1])
+            ->assertStatus(422)
+            ->assertJson(['success' => false, 'message' => 'Stok tidak mencukupi. Tersedia: 10']);
+    }
+
+    public function test_update_cart_uses_unit_sell_price(): void
+    {
+        $this->openShiftForCashier();
+        $product = $this->makeProduct(100);
+
+        $pcs = Unit::where('code', 'PCS')->firstOrFail();
+        $box = Unit::where('code', 'BOX')->firstOrFail();
+        $product->units()->sync([
+            $pcs->id => ['is_base' => true, 'conversion_factor' => 1, 'buy_price' => 45000, 'sell_price' => 60000],
+            $box->id => ['is_base' => false, 'conversion_factor' => 12, 'buy_price' => 540000, 'sell_price' => 660000],
+        ]);
+
+        $cart = Cart::create([
+            'cashier_id' => $this->cashier->id,
+            'warehouse_id' => $this->warehouse->id,
+            'product_id' => $product->id,
+            'unit_id' => $box->id,
+            'conversion_factor' => 12,
+            'qty' => 1,
+            'price' => 660000,
+        ]);
+
+        $this->from(route('transactions.index'))
+            ->patch(route('transactions.updateCart', $cart->id), ['qty' => 2]);
+
+        $cart = $cart->fresh();
+        $this->assertSame(2, (int) $cart->qty);
+        $this->assertSame(1320000, (int) $cart->price);
+    }
+}

--- a/tests/Feature/Transactions/CashPaymentValidationTest.php
+++ b/tests/Feature/Transactions/CashPaymentValidationTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\PaymentSetting;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class CashPaymentValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $cashier = User::where('email', 'cashier@gmail.com')->first();
+        $cashier->markEmailAsVerified();
+        $this->actingAs($cashier);
+
+        $category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'categories/test.jpg',
+            'description' => 'Kategori untuk test',
+        ]);
+
+        $warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->warehouse = $warehouse;
+
+        $this->product = Product::create([
+            'title' => 'Produk Test',
+            'sku' => 'SKU-CASH-'.uniqid(),
+            'buy_price' => 5000,
+            'sell_price' => 10000,
+            'stock' => 100,
+            'image' => 'products/test.jpg',
+            'barcode' => 'BC-CASH-'.uniqid(),
+            'description' => 'Deskripsi produk test',
+            'tax_rate' => 0,
+            'category_id' => $category->id,
+        ]);
+        $warehouse->products()->attach($this->product->id, ['stock' => 100]);
+
+        $this->cashier = $cashier;
+
+        app(CashierShiftService::class)->openShift($cashier, $cashier, 0, null, $warehouse->id);
+
+        $this->post(route('transactions.addToCart'), [
+            'product_id' => $this->product->id,
+            'sell_price' => 10000,
+            'qty' => 1,
+        ])->assertSessionHasNoErrors();
+    }
+
+    private function stock(): int
+    {
+        return (int) $this->warehouse->products()->where('product_id', $this->product->id)->first()->pivot->stock;
+    }
+
+    public function test_cash_zero_is_rejected_without_side_effects(): void
+    {
+        $this->post(route('transactions.store'), [
+            'payment_method' => 'cash',
+            'cash' => 0,
+        ])->assertSessionHasErrors('cash');
+
+        $this->assertEquals(0, Transaction::count());
+        $this->assertEquals(100, $this->stock());
+        $this->assertEquals(1, Cart::where('product_id', $this->product->id)->count());
+    }
+
+    public function test_cash_below_total_is_rejected(): void
+    {
+        $this->post(route('transactions.store'), [
+            'payment_method' => 'cash',
+            'cash' => 9999,
+        ])->assertSessionHasErrors('cash');
+
+        $this->assertEquals(0, Transaction::count());
+        $this->assertEquals(100, $this->stock());
+    }
+
+    public function test_cash_equal_total_succeeds(): void
+    {
+        $response = $this->post(route('transactions.store'), [
+            'payment_method' => 'cash',
+            'cash' => 10000,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        $transaction = Transaction::latest('id')->first();
+        $this->assertNotNull($transaction);
+        $this->assertEquals('cash', $transaction->payment_method);
+        $this->assertEquals('paid', $transaction->payment_status);
+        $this->assertEquals(10000, (int) $transaction->cash);
+        $this->assertEquals(0, (int) $transaction->change);
+        $this->assertEquals(99, $this->stock());
+    }
+
+    public function test_cash_above_total_succeeds_with_change(): void
+    {
+        $this->post(route('transactions.store'), [
+            'payment_method' => 'cash',
+            'cash' => 50000,
+        ])->assertSessionHasNoErrors();
+
+        $transaction = Transaction::latest('id')->first();
+        $this->assertEquals(40000, (int) $transaction->change);
+        $this->assertEquals(99, $this->stock());
+    }
+
+    public function test_gateway_payment_with_zero_cash_still_succeeds(): void
+    {
+        PaymentSetting::create([
+            'default_gateway' => 'xendit',
+            'xendit_enabled' => true,
+            'xendit_secret_key' => 'secret-key',
+            'xendit_public_key' => 'public-key',
+        ]);
+
+        Http::fake([
+            'https://api.xendit.co/*' => Http::response([
+                'id' => 'xendit-inv-123',
+                'invoice_url' => 'https://checkout.xendit.co/web/123',
+            ], 200),
+        ]);
+
+        $this->post(route('transactions.store'), [
+            'payment_gateway' => 'xendit',
+            'cash' => 0,
+        ])->assertSessionHasNoErrors();
+
+        $transaction = Transaction::latest('id')->first();
+        $this->assertNotNull($transaction);
+        $this->assertEquals('xendit', $transaction->payment_method);
+        $this->assertEquals('pending', $transaction->payment_status);
+        $this->assertEquals('https://checkout.xendit.co/web/123', $transaction->payment_url);
+        $this->assertEquals(99, $this->stock());
+    }
+}

--- a/tests/Feature/Transactions/CheckoutStockIntegrityTest.php
+++ b/tests/Feature/Transactions/CheckoutStockIntegrityTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Models\Cart;
+use App\Models\CashierShift;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductBatch;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use App\Services\CashierShiftService;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CheckoutStockIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->cashier = User::where('email', 'cashier@gmail.com')->first();
+        $this->cashier->markEmailAsVerified();
+
+        $this->pusat = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $this->category = Category::create([
+            'name' => 'Kategori Test',
+            'image' => 'test.png',
+            'description' => 'desc',
+        ]);
+
+        app(CashierShiftService::class)->openShift($this->cashier, $this->cashier, 0, null, $this->pusat->id);
+    }
+
+    private static int $seq = 0;
+
+    private function createProduct(int $stock = 10): Product
+    {
+        self::$seq++;
+
+        $product = Product::create([
+            'title' => 'Produk Integrity '.self::$seq,
+            'sku' => 'SKU-INT-'.self::$seq,
+            'barcode' => 'BC-INT-'.self::$seq,
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 1000,
+            'sell_price' => 2000,
+            'stock' => $stock,
+            'tax_rate' => 0,
+        ]);
+
+        $product->warehouses()->attach($this->pusat->id, ['stock' => $stock]);
+
+        return $product;
+    }
+
+    private function openShiftFor(User $user, int $warehouseId): CashierShift
+    {
+        return CashierShift::create([
+            'user_id' => $user->id,
+            'opened_by' => $user->id,
+            'opened_at' => now(),
+            'opening_cash' => 100000,
+            'expected_cash' => 100000,
+            'status' => 'open',
+            'warehouse_id' => $warehouseId,
+        ]);
+    }
+
+    public function test_checkout_rejects_cart_exceeding_available_stock_atomic(): void
+    {
+        $product = $this->createProduct(5);
+
+        // Bypass the add-to-cart guard: simulate a cart created when stock was higher
+        Cart::create([
+            'cashier_id' => $this->cashier->id,
+            'warehouse_id' => $this->pusat->id,
+            'product_id' => $product->id,
+            'qty' => 10,
+            'price' => 20000,
+            'conversion_factor' => 1,
+        ]);
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertSessionHasErrors('stock');
+
+        $this->assertSame(0, Transaction::count());
+        $this->assertSame(5, $product->fresh()->stock);
+        $this->assertSame(5, (int) $product->fresh()->warehouses()->where('warehouse_id', $this->pusat->id)->first()->pivot->stock);
+        $this->assertSame(1, Cart::count());
+    }
+
+    public function test_checkout_rejects_second_item_shortage_and_rolls_back_first_item(): void
+    {
+        $productA = $this->createProduct(100);
+        $productB = $this->createProduct(3);
+
+        // Both pass the add-to-cart guard (stock was sufficient at add time)
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $productA->id,
+            'qty' => 5,
+        ])->assertRedirect();
+
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $productB->id,
+            'qty' => 2,
+        ])->assertRedirect();
+
+        // Simulate stock dropping below cart qty before checkout
+        $productB->warehouses()->updateExistingPivot($this->pusat->id, ['stock' => 1]);
+        $productB->update(['stock' => 1]);
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertSessionHasErrors('stock');
+
+        $this->assertSame(0, Transaction::count());
+        // First product decrement must have been rolled back too
+        $this->assertSame(100, $productA->fresh()->stock);
+        $this->assertSame(2, Cart::count());
+    }
+
+    public function test_composite_checkout_short_component_rolls_back_all_decrements(): void
+    {
+        $componentA = Product::create([
+            'title' => 'Komponen A',
+            'sku' => 'SKU-CA-'.Str::upper(Str::random(6)),
+            'barcode' => 'BC-CA-'.Str::upper(Str::random(6)),
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 1000,
+            'sell_price' => 6000,
+            'stock' => 5,
+            'tax_rate' => 0,
+        ]);
+        $componentA->warehouses()->attach($this->pusat->id, ['stock' => 5]);
+
+        $componentB = Product::create([
+            'title' => 'Komponen B',
+            'sku' => 'SKU-CB-'.Str::upper(Str::random(6)),
+            'barcode' => 'BC-CB-'.Str::upper(Str::random(6)),
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 1000,
+            'sell_price' => 4000,
+            'stock' => 8,
+            'tax_rate' => 0,
+        ]);
+        $componentB->warehouses()->attach($this->pusat->id, ['stock' => 8]);
+
+        $composite = Product::create([
+            'title' => 'Paket Integrity',
+            'sku' => 'SKU-PI-'.Str::upper(Str::random(6)),
+            'barcode' => 'BC-PI-'.Str::upper(Str::random(6)),
+            'image' => 'product.png',
+            'description' => 'desc',
+            'category_id' => $this->category->id,
+            'buy_price' => 0,
+            'sell_price' => 0,
+            'stock' => 0,
+            'is_composite' => true,
+            'tax_rate' => 0,
+        ]);
+        $composite->components()->attach([
+            $componentA->id => ['qty' => 1],
+            $componentB->id => ['qty' => 3],
+        ]);
+
+        // Component B needs 3x per composite; add 2 composites = 6 needed
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $composite->id,
+            'qty' => 2,
+        ])->assertRedirect();
+
+        // Stock drops to 5 (below the 6 needed) before checkout
+        $componentB->warehouses()->updateExistingPivot($this->pusat->id, ['stock' => 5]);
+        $componentB->update(['stock' => 5]);
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertSessionHasErrors('stock');
+
+        $this->assertSame(0, Transaction::count());
+        $this->assertSame(5, $componentA->fresh()->stock);
+        $this->assertSame(5, $componentB->fresh()->stock);
+        $this->assertSame(1, Cart::count());
+    }
+
+    public function test_checkout_rejects_partial_batch_coverage(): void
+    {
+        $product = $this->createProduct(30);
+
+        // Batches cover only 5 of the 30 aggregate units
+        ProductBatch::create([
+            'product_id' => $product->id,
+            'warehouse_id' => $this->pusat->id,
+            'batch_number' => 'BATCH-X',
+            'expired_at' => now()->addDays(10)->toDateString(),
+            'received_at' => '2026-01-01',
+            'stock' => 5,
+        ]);
+
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'qty' => 8,
+        ])->assertRedirect();
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertSessionHasErrors('stock');
+
+        $this->assertSame(0, Transaction::count());
+        $this->assertSame(30, $product->fresh()->stock);
+        $this->assertSame(5, (int) ProductBatch::where('batch_number', 'BATCH-X')->first()->stock);
+        $this->assertSame(1, Cart::count());
+    }
+
+    public function test_checkout_succeeds_when_batch_coverage_is_sufficient(): void
+    {
+        $product = $this->createProduct(30);
+
+        ProductBatch::create([
+            'product_id' => $product->id,
+            'warehouse_id' => $this->pusat->id,
+            'batch_number' => 'BATCH-Y',
+            'expired_at' => now()->addDays(10)->toDateString(),
+            'received_at' => '2026-01-01',
+            'stock' => 10,
+        ]);
+
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'qty' => 8,
+        ])->assertRedirect();
+
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertRedirect();
+
+        $this->assertSame(1, Transaction::count());
+        $this->assertSame(22, $product->fresh()->stock);
+        $this->assertSame(2, (int) ProductBatch::where('batch_number', 'BATCH-Y')->first()->stock);
+        $this->assertSame(0, Cart::count());
+    }
+
+    public function test_other_cashier_cart_is_ignored_when_checking_stock(): void
+    {
+        $other = User::factory()->create();
+        $other->markEmailAsVerified();
+
+        $product = $this->createProduct(2);
+
+        // Other cashier holds a cart for the same product beyond remaining stock
+        Cart::create([
+            'cashier_id' => $other->id,
+            'warehouse_id' => $this->pusat->id,
+            'product_id' => $product->id,
+            'qty' => 2,
+            'price' => 4000,
+            'conversion_factor' => 1,
+        ]);
+        $this->openShiftFor($other, $this->pusat->id);
+
+        $this->actingAs($this->cashier)->post(route('transactions.addToCart'), [
+            'product_id' => $product->id,
+            'qty' => 1,
+        ])->assertRedirect();
+
+        // Only the acting cashier's cart is considered at checkout
+        $this->actingAs($this->cashier)
+            ->post(route('transactions.store'), ['payment_method' => 'cash', 'cash' => 50000])
+            ->assertRedirect();
+
+        $this->assertSame(1, $product->fresh()->stock);
+    }
+}

--- a/tests/Feature/Transactions/DiscountApprovalStateTest.php
+++ b/tests/Feature/Transactions/DiscountApprovalStateTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Feature\Transactions;
+
+use App\Models\BankAccount;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Models\Warehouse;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DiscountApprovalStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed([PermissionSeeder::class, RoleSeeder::class, UserSeeder::class]);
+
+        $this->admin = User::where('email', 'arya@gmail.com')->first();
+        $this->admin->markEmailAsVerified();
+        $this->actingAs($this->admin);
+
+        $this->warehouse = Warehouse::create([
+            'code' => 'PUSAT',
+            'name' => 'Gudang Pusat',
+            'type' => 'main',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private static int $seq = 0;
+
+    private function makeBankAccount(): BankAccount
+    {
+        return BankAccount::create([
+            'bank_name' => 'BCA',
+            'account_number' => '1234567890',
+            'account_name' => 'Toko',
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+    }
+
+    private function makeTransaction(array $overrides = []): Transaction
+    {
+        self::$seq++;
+
+        return Transaction::create(array_merge([
+            'cashier_id' => $this->admin->id,
+            'cashier_shift_id' => null,
+            'warehouse_id' => $this->warehouse->id,
+            'invoice' => 'INV-APPROVE-'.Str::upper(Str::random(10)),
+            'grand_total' => 100000,
+            'discount' => 20000,
+            'cash' => 100000,
+            'change' => 0,
+            'payment_method' => 'cash',
+            'payment_status' => 'pending_approval',
+            'discount_approval_status' => 'pending',
+            'tax_rate' => 0,
+            'tax_total' => 0,
+        ], $overrides));
+    }
+
+    private function confirmPassword(): void
+    {
+        $this->session(['auth.password_confirmed_at' => time()]);
+    }
+
+    public function test_approving_cash_transaction_sets_paid_and_keeps_discount(): void
+    {
+        $transaction = $this->makeTransaction();
+
+        $this->from(route('dashboard.access'))
+            ->post(route('discount-approvals.approve', $transaction))
+            ->assertSessionHas('success');
+
+        $transaction = $transaction->fresh();
+        $this->assertEquals('approved', $transaction->discount_approval_status);
+        $this->assertEquals('paid', $transaction->payment_status);
+        $this->assertEquals(20000, $transaction->discount);
+        $this->assertEquals(100000, $transaction->grand_total);
+    }
+
+    public function test_approving_bank_transfer_transaction_stays_pending(): void
+    {
+        $transaction = $this->makeTransaction([
+            'payment_method' => 'bank_transfer',
+            'bank_account_id' => null,
+            'payment_status' => 'pending_approval',
+        ]);
+
+        $this->from(route('dashboard.access'))
+            ->post(route('discount-approvals.approve', $transaction))
+            ->assertSessionHas('success');
+
+        $transaction = $transaction->fresh();
+        $this->assertEquals('approved', $transaction->discount_approval_status);
+        $this->assertEquals('pending', $transaction->payment_status);
+        $this->assertEquals(20000, $transaction->discount);
+    }
+
+    public function test_denying_transaction_removes_discount_and_marks_unpaid(): void
+    {
+        $transaction = $this->makeTransaction();
+
+        $this->from(route('dashboard.access'))
+            ->post(route('discount-approvals.deny', $transaction), ['notes' => 'Melebihi limit'])
+            ->assertSessionHas('success');
+
+        $transaction = $transaction->fresh();
+        $this->assertEquals('denied', $transaction->discount_approval_status);
+        $this->assertEquals('unpaid', $transaction->payment_status);
+        $this->assertEquals(0, $transaction->discount);
+        $this->assertEquals(120000, $transaction->grand_total);
+    }
+
+    public function test_approving_already_resolved_transaction_returns_404(): void
+    {
+        $transaction = $this->makeTransaction(['discount_approval_status' => 'approved']);
+
+        $this->post(route('discount-approvals.approve', $transaction))
+            ->assertNotFound();
+    }
+
+    public function test_confirm_payment_marks_bank_transfer_pending_as_paid(): void
+    {
+        $this->confirmPassword();
+
+        $transaction = $this->makeTransaction([
+            'payment_method' => 'bank_transfer',
+            'bank_account_id' => $this->makeBankAccount()->id,
+            'payment_status' => 'pending',
+            'discount_approval_status' => null,
+        ]);
+
+        $this->from(route('dashboard.access'))
+            ->patch(route('transactions.confirm-payment', $transaction))
+            ->assertSessionHas('success');
+
+        $this->assertEquals('paid', $transaction->fresh()->payment_status);
+    }
+
+    public function test_confirm_payment_rejects_cash_transaction(): void
+    {
+        $this->confirmPassword();
+
+        $transaction = $this->makeTransaction([
+            'payment_method' => 'cash',
+            'payment_status' => 'pending',
+            'discount_approval_status' => null,
+        ]);
+
+        $this->from(route('dashboard.access'))
+            ->patch(route('transactions.confirm-payment', $transaction))
+            ->assertSessionHas('error');
+
+        $this->assertEquals('pending', $transaction->fresh()->payment_status);
+    }
+
+    public function test_confirm_payment_rejects_bank_transfer_without_bank_account(): void
+    {
+        $this->confirmPassword();
+
+        $transaction = $this->makeTransaction([
+            'payment_method' => 'bank_transfer',
+            'bank_account_id' => null,
+            'payment_status' => 'pending',
+            'discount_approval_status' => null,
+        ]);
+
+        $this->from(route('dashboard.access'))
+            ->patch(route('transactions.confirm-payment', $transaction))
+            ->assertSessionHas('error');
+
+        $this->assertEquals('pending', $transaction->fresh()->payment_status);
+    }
+
+    public function test_confirm_payment_rejects_paid_transaction(): void
+    {
+        $this->confirmPassword();
+
+        $transaction = $this->makeTransaction([
+            'payment_method' => 'bank_transfer',
+            'bank_account_id' => $this->makeBankAccount()->id,
+            'payment_status' => 'paid',
+            'discount_approval_status' => null,
+        ]);
+
+        $this->from(route('dashboard.access'))
+            ->patch(route('transactions.confirm-payment', $transaction))
+            ->assertSessionHas('error');
+
+        $this->assertEquals('paid', $transaction->fresh()->payment_status);
+    }
+}


### PR DESCRIPTION
## Ringkasan

Hasil audit menyeluruh sebelumnya: memperbaiki bug keamanan, pembayaran, integritas stok, dan fitur parsial. 13 fase, 13 commit, 45 file, +3356/−326. Full suite: **271 passed (1199 assertions)**, vite build OK.

## Fase & Perbaikan

1. **Keamanan dokumen publik** (9000efa) — invoice publik `GET /share/transactions/{invoice}` kini butuh access_token (404 jika tidak cocok).
2. **Authorization API** (fc9b31b) — master-data `/api/v1` kini enforce Sanctum abilities (products/customers/categories/warehouses/suppliers); MissingAbilityException → 403.
3. **Tolak cash kurang** (0f54dee) — checkout web & API menolak cash < grand total (422/error), tanpa decrement stok.
4. **Cart ownership + validasi unit** (a5f28ee) — delete cart di-scope cashier; unit_id divalidasi milik produk; updateCart pakai base-qty + stok gudang.
5. **Checkout stock locking** (da30624) — pivot & batch di-lock (lockForUpdate) saat checkout; re-check stok; FEFO partial-coverage ditolak; rollback penuh bila gagal.
6. **Stock transfer atomic** (f265e6f) — send/receive/cancel lock baris transfer, re-check status dalam transaksi; pivot firstOrCreate (bukan updateOrCreate).
7. **Goods receiving atomic** (58da576) — tolak item PO duplikat; lock PO+items; re-check status; qty > outstanding ditolak.
8. **Payment receivable/payable locking** (5e89a0c) — lockForUpdate baris; overpay ditolak; status unpaid/partial/paid konsisten.
9. **Discount approval + bank transfer state machine** (fae277d) — approval tidak lagi menandai paid untuk deny; payment_status mengikuti payment_method; confirm-payment hanya untuk bank_transfer ber-status eligible.
10. **Dine-in aman** (c46e996) — pay_online ditolak backend + tombol dihapus; stok divalidasi saat order; accept() lock + re-check stok + wajib shift aktif. Menu publik diperbaiki (previewProducts mapping).
11. **Status dine + voucher atomic** (60ff4be) — status-check minimal + expired 24 jam + throttle; voucher single-use atomic (whereKey + is_used=false).
12. **Batch allocation + reconcile** (b11d6f9) — tabel & model `transaction_detail_batch_allocations`; setiap batch FEFO tercatat; command `inventory:reconcile` (--report/--fix).
13. **Cleanup** (2653145) — retry unique-collision nomor dokumen (ST/GR); invoice pakai Str::random (bukan rand()); Menu price-lists route fix; hapus dead profile block; API POS product list difilter stok gudang (parity web).

## Test baru

PublicInvoiceAuthorizationTest, ApiAuthorizationTest, CashPaymentValidationTest, PosApiCashValidationTest, CartAuthorizationTest, CartValidationTest, CheckoutStockIntegrityTest, StockTransferIntegrityTest, GoodsReceivingTest(+2), PaymentIntegrityTest, DiscountApprovalStateTest, DineOrderTest, DineOrderStatusTest, CustomerVoucherConcurrencyTest, BatchAllocationTest, InventoryReconcileCommandTest.
